### PR TITLE
Adds build_sources to git ignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 node_modules/
 lib/
+build_sources/


### PR DESCRIPTION
Adds build_sources to git ignore

Updating the code generator pipeline to move all the old code in `src` folder to the `build_sources` directory. It should resolve the issue with attempting to delete deeply nested folders / files using powershell