### PR TITLE
Revert "Bump chai from 4.3.10 to 5.0.0"

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -25,7 +25,7 @@
                 "@types/chai": "^4.3.0",
                 "@types/mocha": "^10.0.0",
                 "@types/node": "^20.1.0",
-                "chai": "^5.0.0",
+                "chai": "^4.3.6",
                 "mocha": "^10.1.0",
                 "typescript": "^5.0.2"
             }
@@ -415,12 +415,12 @@
             "dev": true
         },
         "node_modules/assertion-error": {
-            "version": "2.0.1",
-            "resolved": "https://registry.npmjs.org/assertion-error/-/assertion-error-2.0.1.tgz",
-            "integrity": "sha512-Izi8RQcffqCeNVgFigKli1ssklIbpHnCYc6AknXGYoB6grJqyeby7jv12JUQgmTAnIDnbck1uxksT4dzN3PWBA==",
+            "version": "1.1.0",
+            "resolved": "https://registry.npmjs.org/assertion-error/-/assertion-error-1.1.0.tgz",
+            "integrity": "sha512-jgsaNduz+ndvGyFt3uSuWqvy4lCnIJiovtouQN5JZHOKCS2QuhEdbcQHFhVksz2N2U9hXJo8odG7ETyWlEeuDw==",
             "dev": true,
             "engines": {
-                "node": ">=12"
+                "node": "*"
             }
         },
         "node_modules/asynckit": {
@@ -490,19 +490,21 @@
             }
         },
         "node_modules/chai": {
-            "version": "5.0.0",
-            "resolved": "https://registry.npmjs.org/chai/-/chai-5.0.0.tgz",
-            "integrity": "sha512-HO5p0oEKd5M6HEcwOkNAThAE3j960vIZvVcc0t2tI06Dd0ATu69cEnMB2wOhC5/ZyQ6m67w3ePjU/HzXsSsdBA==",
+            "version": "4.3.10",
+            "resolved": "https://registry.npmjs.org/chai/-/chai-4.3.10.tgz",
+            "integrity": "sha512-0UXG04VuVbruMUYbJ6JctvH0YnC/4q3/AkT18q4NaITo91CUm0liMS9VqzT9vZhVQ/1eqPanMWjBM+Juhfb/9g==",
             "dev": true,
             "dependencies": {
-                "assertion-error": "^2.0.1",
-                "check-error": "^2.0.0",
-                "deep-eql": "^5.0.1",
-                "loupe": "^3.0.0",
-                "pathval": "^2.0.0"
+                "assertion-error": "^1.1.0",
+                "check-error": "^1.0.3",
+                "deep-eql": "^4.1.3",
+                "get-func-name": "^2.0.2",
+                "loupe": "^2.3.6",
+                "pathval": "^1.1.1",
+                "type-detect": "^4.0.8"
             },
             "engines": {
-                "node": ">=12"
+                "node": ">=4"
             }
         },
         "node_modules/chalk": {
@@ -534,12 +536,15 @@
             }
         },
         "node_modules/check-error": {
-            "version": "2.0.0",
-            "resolved": "https://registry.npmjs.org/check-error/-/check-error-2.0.0.tgz",
-            "integrity": "sha512-tjLAOBHKVxtPoHe/SA7kNOMvhCRdCJ3vETdeY0RuAc9popf+hyaSV6ZEg9hr4cpWF7jmo/JSWEnLDrnijS9Tog==",
+            "version": "1.0.3",
+            "resolved": "https://registry.npmjs.org/check-error/-/check-error-1.0.3.tgz",
+            "integrity": "sha512-iKEoDYaRmd1mxM90a2OEfWhjsjPpYPuQ+lMYsoxB126+t8fw7ySEO48nmDg5COTjxDI65/Y2OWpeEHk3ZOe8zg==",
             "dev": true,
+            "dependencies": {
+                "get-func-name": "^2.0.2"
+            },
             "engines": {
-                "node": ">= 16"
+                "node": "*"
             }
         },
         "node_modules/chokidar": {
@@ -646,10 +651,13 @@
             }
         },
         "node_modules/deep-eql": {
-            "version": "5.0.1",
-            "resolved": "https://registry.npmjs.org/deep-eql/-/deep-eql-5.0.1.tgz",
-            "integrity": "sha512-nwQCf6ne2gez3o1MxWifqkciwt0zhl0LO1/UwVu4uMBuPmflWM4oQ70XMqHqnBJA+nhzncaqL9HVL6KkHJ28lw==",
+            "version": "4.1.3",
+            "resolved": "https://registry.npmjs.org/deep-eql/-/deep-eql-4.1.3.tgz",
+            "integrity": "sha512-WaEtAOpRA1MQ0eohqZjpGD8zdI0Ovsm8mmFhaDN8dvDZzyoUMcYDnf5Y6iu7HTXxf8JDS23qWa4a+hKCDyOPzw==",
             "dev": true,
+            "dependencies": {
+                "type-detect": "^4.0.0"
+            },
             "engines": {
                 "node": ">=6"
             }
@@ -1184,9 +1192,9 @@
             }
         },
         "node_modules/loupe": {
-            "version": "3.0.2",
-            "resolved": "https://registry.npmjs.org/loupe/-/loupe-3.0.2.tgz",
-            "integrity": "sha512-Tzlkbynv7dtqxTROe54Il+J4e/zG2iehtJGZUYpTv8WzlkW9qyEcE83UhGJCeuF3SCfzHuM5VWhBi47phV3+AQ==",
+            "version": "2.3.7",
+            "resolved": "https://registry.npmjs.org/loupe/-/loupe-2.3.7.tgz",
+            "integrity": "sha512-zSMINGVYkdpYSOBmLi0D1Uo7JU9nVdQKrHxC8eYlV+9YKK9WePqAlL7lSlorG/U2Fw1w0hTBmaa/jrQ3UbPHtA==",
             "dev": true,
             "dependencies": {
                 "get-func-name": "^2.0.1"
@@ -1404,12 +1412,12 @@
             }
         },
         "node_modules/pathval": {
-            "version": "2.0.0",
-            "resolved": "https://registry.npmjs.org/pathval/-/pathval-2.0.0.tgz",
-            "integrity": "sha512-vE7JKRyES09KiunauX7nd2Q9/L7lhok4smP9RZTDeD4MVs72Dp2qNFVz39Nz5a0FVEW0BJR6C0DYrq6unoziZA==",
+            "version": "1.1.1",
+            "resolved": "https://registry.npmjs.org/pathval/-/pathval-1.1.1.tgz",
+            "integrity": "sha512-Dp6zGqpTdETdR63lehJYPeIOqpiNBNtc7BpWSLrOje7UaIsE5aY92r/AunQA7rsXvet3lrJ3JnZX29UPTKXyKQ==",
             "dev": true,
             "engines": {
-                "node": ">= 14.16"
+                "node": "*"
             }
         },
         "node_modules/picomatch": {
@@ -1587,6 +1595,15 @@
             "version": "2.6.2",
             "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.6.2.tgz",
             "integrity": "sha512-AEYxH93jGFPn/a2iVAwW87VuUIkR1FVUKB77NwMF7nBTDkDrrT/Hpt/IrCJ0QXhW27jTBDcf5ZY7w6RiqTMw2Q=="
+        },
+        "node_modules/type-detect": {
+            "version": "4.0.8",
+            "resolved": "https://registry.npmjs.org/type-detect/-/type-detect-4.0.8.tgz",
+            "integrity": "sha512-0fr/mIH1dlO+x7TlcMy+bIDqKPsw/70tVyeHW787goQjhmqaZe10uwLujubK9q9Lg6Fiho1KUKDYz0Z7k7g5/g==",
+            "dev": true,
+            "engines": {
+                "node": ">=4"
+            }
         },
         "node_modules/typescript": {
             "version": "5.3.3",

--- a/package.json
+++ b/package.json
@@ -40,7 +40,7 @@
         "@types/chai": "^4.3.0",
         "@types/mocha": "^10.0.0",
         "@types/node": "^20.1.0",
-        "chai": "^5.0.0",
+        "chai": "^4.3.6",
         "mocha": "^10.1.0",
         "typescript": "^5.0.2"
     }


### PR DESCRIPTION
Reverts microsoftgraph/msgraph-sdk-typescript#464

integration tests are failing because of how imports are emitted, this is masked by the fact that secrets are not defined for dependabot.
We should:
- define the secrets for dependabot
- correct the configuration to emit ESM + imports

https://github.com/microsoftgraph/msgraph-sdk-typescript/actions/runs/7451435766/job/20272549152