### PR TITLE
chore: drop Node.js 18 from CI build matrix

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -21,7 +21,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        node-version: [18.x, 20.x, 22.x]
+        node-version: [20.x, 22.x]
         # Single version should work for compilation testing
 
     steps:


### PR DESCRIPTION
Remove Node.js 18.x from the CI build/test matrix, keeping only Node.js 20.x and 22.x. Node.js 18 reached end-of-life on 2025-04-30 and is no longer receiving security updates.
same as https://github.com/microsoftgraph/msgraph-sdk-typescript-core/pull/559