### PR TITLE
chore: consolidate dependabot updates

### DIFF
--- a/.github/workflows/auto-merge-dependabot.yml
+++ b/.github/workflows/auto-merge-dependabot.yml
@@ -19,7 +19,7 @@ jobs:
     steps:
       - name: Dependabot metadata
         id: metadata
-        uses: dependabot/fetch-metadata@v2.5.0
+        uses: dependabot/fetch-metadata@v3.1.0
         with:
           github-token: "${{ secrets.GITHUB_TOKEN }}"
 

--- a/.github/workflows/release-please-gha.yml
+++ b/.github/workflows/release-please-gha.yml
@@ -29,7 +29,7 @@ jobs:
           private-key: ${{ secrets.RELEASE_PLEASE_TOKEN_PROVIDER_PEM }}
 
       - name: Release Please
-        uses: googleapis/release-please-action@v4
+        uses: googleapis/release-please-action@v5
         with:
           token: ${{ steps.app-token.outputs.token }}
           config-file: release-please-config.json

--- a/.github/workflows/validate-public-api-surface.yml
+++ b/.github/workflows/validate-public-api-surface.yml
@@ -33,14 +33,14 @@ jobs:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       - name: Upload patch file as artifact
         if: always()
-        uses: actions/upload-artifact@v6
+        uses: actions/upload-artifact@v7
         continue-on-error: true
         with:
           name: patch
           path: '*.patch'
       - name: Upload explanations file as artifact
         if: always()
-        uses: actions/upload-artifact@v6
+        uses: actions/upload-artifact@v7
         continue-on-error: true
         with:
           name: explanations

--- a/package-lock.json
+++ b/package-lock.json
@@ -103,9 +103,9 @@
       }
     },
     "node_modules/@azure/identity": {
-      "version": "4.13.0",
-      "resolved": "https://registry.npmjs.org/@azure/identity/-/identity-4.13.0.tgz",
-      "integrity": "sha512-uWC0fssc+hs1TGGVkkghiaFkkS7NkTxfnCH+Hdg+yTehTpMcehpok4PgUKKdyCH+9ldu6FhiHRv84Ntqj1vVcw==",
+      "version": "4.13.1",
+      "resolved": "https://registry.npmjs.org/@azure/identity/-/identity-4.13.1.tgz",
+      "integrity": "sha512-5C/2WD5Vb1lHnZS16dNQRPMjN6oV/Upba+C9nBIs15PmOi6A3ZGs4Lr2u60zw4S04gi+u3cEXiqTVP7M4Pz3kw==",
       "license": "MIT",
       "dependencies": {
         "@azure/abort-controller": "^2.0.0",
@@ -115,8 +115,8 @@
         "@azure/core-tracing": "^1.0.0",
         "@azure/core-util": "^1.11.0",
         "@azure/logger": "^1.0.0",
-        "@azure/msal-browser": "^4.2.0",
-        "@azure/msal-node": "^3.5.0",
+        "@azure/msal-browser": "^5.5.0",
+        "@azure/msal-node": "^5.1.0",
         "open": "^10.1.0",
         "tslib": "^2.2.0"
       },
@@ -137,47 +137,37 @@
       }
     },
     "node_modules/@azure/msal-browser": {
-      "version": "4.5.0",
-      "resolved": "https://registry.npmjs.org/@azure/msal-browser/-/msal-browser-4.5.0.tgz",
-      "integrity": "sha512-H7mWmu8yI0n0XxhJobrgncXI6IU5h8DKMiWDHL5y+Dc58cdg26GbmaMUehbUkdKAQV2OTiFa4FUa6Fdu/wIxBg==",
+      "version": "5.10.0",
+      "resolved": "https://registry.npmjs.org/@azure/msal-browser/-/msal-browser-5.10.0.tgz",
+      "integrity": "sha512-2Y4TlG5mCfxviHutfW50i8Xd8xhGKTgieL02vMYOE5ZbZrVM+drKSGD//tweRAmlmqqp+F9vrKoHWri/buzxWQ==",
       "license": "MIT",
       "dependencies": {
-        "@azure/msal-common": "15.2.0"
+        "@azure/msal-common": "16.6.0"
       },
       "engines": {
         "node": ">=0.8.0"
       }
     },
     "node_modules/@azure/msal-common": {
-      "version": "15.2.0",
-      "resolved": "https://registry.npmjs.org/@azure/msal-common/-/msal-common-15.2.0.tgz",
-      "integrity": "sha512-HiYfGAKthisUYqHG1nImCf/uzcyS31wng3o+CycWLIM9chnYJ9Lk6jZ30Y6YiYYpTQ9+z/FGUpiKKekd3Arc0A==",
+      "version": "16.6.0",
+      "resolved": "https://registry.npmjs.org/@azure/msal-common/-/msal-common-16.6.0.tgz",
+      "integrity": "sha512-FemGljX0csPlBMUE5GUan7BfRn1emeMRUhHSARhqzLN6LA9nt+MgzmAQ1xVqdLm+6plVoxsq9mS5eoyKtpPSgA==",
       "license": "MIT",
       "engines": {
         "node": ">=0.8.0"
       }
     },
     "node_modules/@azure/msal-node": {
-      "version": "3.5.1",
-      "resolved": "https://registry.npmjs.org/@azure/msal-node/-/msal-node-3.5.1.tgz",
-      "integrity": "sha512-dkgMYM5B6tI88r/oqf5bYd93WkenQpaWwiszJDk7avVjso8cmuKRTW97dA1RMi6RhihZFLtY1VtWxU9+sW2T5g==",
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/@azure/msal-node/-/msal-node-5.2.0.tgz",
+      "integrity": "sha512-b/ak8XAqpnGk1N1nsyTVV0Remp48BP3QrGQZ1uCMcvg2S8X1eSXzhHQZEae2oX276Q4KFAqCUswanDtcvIKLrw==",
       "license": "MIT",
       "dependencies": {
-        "@azure/msal-common": "15.5.1",
-        "jsonwebtoken": "^9.0.0",
-        "uuid": "^8.3.0"
+        "@azure/msal-common": "16.6.0",
+        "jsonwebtoken": "^9.0.0"
       },
       "engines": {
-        "node": ">=16"
-      }
-    },
-    "node_modules/@azure/msal-node/node_modules/@azure/msal-common": {
-      "version": "15.5.1",
-      "resolved": "https://registry.npmjs.org/@azure/msal-common/-/msal-common-15.5.1.tgz",
-      "integrity": "sha512-oxK0khbc4Bg1bKQnqDr7ikULhVL2OHgSrIq0Vlh4b6+hm4r0lr6zPMQE8ZvmacJuh+ZZGKBM5iIObhF1q1QimQ==",
-      "license": "MIT",
-      "engines": {
-        "node": ">=0.8.0"
+        "node": ">=20"
       }
     },
     "node_modules/@isaacs/cliui": {
@@ -199,9 +189,9 @@
       }
     },
     "node_modules/@microsoft/kiota-abstractions": {
-      "version": "1.0.0-preview.99",
-      "resolved": "https://registry.npmjs.org/@microsoft/kiota-abstractions/-/kiota-abstractions-1.0.0-preview.99.tgz",
-      "integrity": "sha512-6qrlwGCO3DbvpA7tszqk7JNQPFPDg8gv5NGMTziwdtHqaQrUALKusm3vdJGPVGrbNiZL6/lBaY5NSUvLtlhRCg==",
+      "version": "1.0.0-preview.100",
+      "resolved": "https://registry.npmjs.org/@microsoft/kiota-abstractions/-/kiota-abstractions-1.0.0-preview.100.tgz",
+      "integrity": "sha512-3s2WYKQ6WLB/0pyDmmv9bigH/3LZ0Mm4ldHskNLBj0U8DYjFzfG729snnEij+hZN0l2XHr37pGBr1MZK8vM7zQ==",
       "license": "MIT",
       "dependencies": {
         "@opentelemetry/api": "^1.7.0",
@@ -211,79 +201,79 @@
       }
     },
     "node_modules/@microsoft/kiota-authentication-azure": {
-      "version": "1.0.0-preview.99",
-      "resolved": "https://registry.npmjs.org/@microsoft/kiota-authentication-azure/-/kiota-authentication-azure-1.0.0-preview.99.tgz",
-      "integrity": "sha512-gPmk/vx15sBMfjfLPgqPanmyVR/rA5HGd3318VtPS28mXxH07Zn30R6PVqSemhIwSxfiGnPiq0SlTj28BQhTKQ==",
+      "version": "1.0.0-preview.100",
+      "resolved": "https://registry.npmjs.org/@microsoft/kiota-authentication-azure/-/kiota-authentication-azure-1.0.0-preview.100.tgz",
+      "integrity": "sha512-RT6LtekPVaFYQ5JHOiMDrYEdsx6RyiRtoGz929m3iy+jS6W2dELWTO4mrtAG3Q+8Tczk1uUwP21tYy/Wyf07lw==",
       "license": "MIT",
       "dependencies": {
         "@azure/core-auth": "^1.5.0",
-        "@microsoft/kiota-abstractions": "^1.0.0-preview.99",
+        "@microsoft/kiota-abstractions": "^1.0.0-preview.100",
         "@opentelemetry/api": "^1.7.0",
         "tslib": "^2.6.2"
       }
     },
     "node_modules/@microsoft/kiota-bundle": {
-      "version": "1.0.0-preview.99",
-      "resolved": "https://registry.npmjs.org/@microsoft/kiota-bundle/-/kiota-bundle-1.0.0-preview.99.tgz",
-      "integrity": "sha512-AxvO+z6UgWMAT2NfXN36CMhAUm/39tUQt8o32axeEJDS/EvZINDAPstbQV+zK7bJRC8kCqUHhCE/fuHX2dXA+g==",
+      "version": "1.0.0-preview.100",
+      "resolved": "https://registry.npmjs.org/@microsoft/kiota-bundle/-/kiota-bundle-1.0.0-preview.100.tgz",
+      "integrity": "sha512-ejYzO9Fku/d5IyYYegdQbMQy9cJd8O9HT8TIUA3Ty/39bzNrGG5b6MltKwqr134jTbfMjraaRmh9wD8p246lhA==",
       "license": "MIT",
       "dependencies": {
-        "@microsoft/kiota-abstractions": "^1.0.0-preview.99",
-        "@microsoft/kiota-http-fetchlibrary": "^1.0.0-preview.99",
-        "@microsoft/kiota-serialization-form": "^1.0.0-preview.99",
-        "@microsoft/kiota-serialization-json": "^1.0.0-preview.99",
-        "@microsoft/kiota-serialization-multipart": "^1.0.0-preview.99",
-        "@microsoft/kiota-serialization-text": "^1.0.0-preview.99"
+        "@microsoft/kiota-abstractions": "^1.0.0-preview.100",
+        "@microsoft/kiota-http-fetchlibrary": "^1.0.0-preview.100",
+        "@microsoft/kiota-serialization-form": "^1.0.0-preview.100",
+        "@microsoft/kiota-serialization-json": "^1.0.0-preview.100",
+        "@microsoft/kiota-serialization-multipart": "^1.0.0-preview.100",
+        "@microsoft/kiota-serialization-text": "^1.0.0-preview.100"
       }
     },
     "node_modules/@microsoft/kiota-http-fetchlibrary": {
-      "version": "1.0.0-preview.99",
-      "resolved": "https://registry.npmjs.org/@microsoft/kiota-http-fetchlibrary/-/kiota-http-fetchlibrary-1.0.0-preview.99.tgz",
-      "integrity": "sha512-lIruiYf8L7DPG0Fm92QN5YK4zx4sh76EtTONUAqBCxt5AtEJ7KQceBajaXQsjfcndUAp9LmDVdqR44o8sc9/mA==",
+      "version": "1.0.0-preview.100",
+      "resolved": "https://registry.npmjs.org/@microsoft/kiota-http-fetchlibrary/-/kiota-http-fetchlibrary-1.0.0-preview.100.tgz",
+      "integrity": "sha512-uS2rhKKjbYiT8JWG8GGVOALB+s4HdDc9hg5tTZMVf3qY5b/us1OKLQ6WgW6USq/kZAuKKWkIq/BQgPCWbHtFTQ==",
       "license": "MIT",
       "dependencies": {
-        "@microsoft/kiota-abstractions": "^1.0.0-preview.99",
+        "@microsoft/kiota-abstractions": "^1.0.0-preview.100",
         "@opentelemetry/api": "^1.7.0",
         "tslib": "^2.6.2"
       }
     },
     "node_modules/@microsoft/kiota-serialization-form": {
-      "version": "1.0.0-preview.99",
-      "resolved": "https://registry.npmjs.org/@microsoft/kiota-serialization-form/-/kiota-serialization-form-1.0.0-preview.99.tgz",
-      "integrity": "sha512-BdXxqNfy+5yWTyxpBguqJYy6E9RRotrDClRcUO89okFcR5N6s6xenjsvGw++q9KWNi7qcHrqaG8xlRz1TLk81Q==",
+      "version": "1.0.0-preview.100",
+      "resolved": "https://registry.npmjs.org/@microsoft/kiota-serialization-form/-/kiota-serialization-form-1.0.0-preview.100.tgz",
+      "integrity": "sha512-SR/yWBtvKYhN2ARR4wVMFb91XgN32DBmLLQmtemdKgL1YWBxVCNAUP/qHbZhrTX7q4kh7jl/S9yrr1S8ySS7AA==",
       "license": "MIT",
       "dependencies": {
-        "@microsoft/kiota-abstractions": "^1.0.0-preview.99",
+        "@microsoft/kiota-abstractions": "^1.0.0-preview.100",
         "tslib": "^2.6.2"
       }
     },
     "node_modules/@microsoft/kiota-serialization-json": {
-      "version": "1.0.0-preview.99",
-      "resolved": "https://registry.npmjs.org/@microsoft/kiota-serialization-json/-/kiota-serialization-json-1.0.0-preview.99.tgz",
-      "integrity": "sha512-kDmMYmB7XkRprlLviEynRPDkE45JDxqiuUopfBRMvNK4qhzFiJTXGLihZ2FG6fdVu9LbV3/W0QxbeGP35kDK6A==",
+      "version": "1.0.0-preview.100",
+      "resolved": "https://registry.npmjs.org/@microsoft/kiota-serialization-json/-/kiota-serialization-json-1.0.0-preview.100.tgz",
+      "integrity": "sha512-4qatf5j0Aeaakdw24jMuIX7W6mf/W2rU9UyAjkIrSjaB7W5n8gsUvhoTcRpPTAFN7pvzQkCbO7Z0paRfdYzhIw==",
       "license": "MIT",
       "dependencies": {
-        "@microsoft/kiota-abstractions": "^1.0.0-preview.99",
+        "@microsoft/kiota-abstractions": "^1.0.0-preview.100",
         "tslib": "^2.6.2"
       }
     },
     "node_modules/@microsoft/kiota-serialization-multipart": {
-      "version": "1.0.0-preview.99",
-      "resolved": "https://registry.npmjs.org/@microsoft/kiota-serialization-multipart/-/kiota-serialization-multipart-1.0.0-preview.99.tgz",
-      "integrity": "sha512-cfviCAVTlZPD+MUgdTIgsX/IfHND+gKQhem3vJeo7l5Qqz2rvvVFXOHwECI19umO9Un1QFKe1V5wg+M+aj90+g==",
+      "version": "1.0.0-preview.100",
+      "resolved": "https://registry.npmjs.org/@microsoft/kiota-serialization-multipart/-/kiota-serialization-multipart-1.0.0-preview.100.tgz",
+      "integrity": "sha512-zwWoLZH6+KsAl05Ijd8HpbU+mct5wb0//ZCGdCkQ/UqsAaoe2xYSoKicxQbVGv9VvSTq0as7iVLwqDeqEI9rDw==",
       "license": "MIT",
       "dependencies": {
-        "@microsoft/kiota-abstractions": "^1.0.0-preview.99",
+        "@microsoft/kiota-abstractions": "^1.0.0-preview.100",
         "tslib": "^2.6.2"
       }
     },
     "node_modules/@microsoft/kiota-serialization-text": {
-      "version": "1.0.0-preview.99",
-      "resolved": "https://registry.npmjs.org/@microsoft/kiota-serialization-text/-/kiota-serialization-text-1.0.0-preview.99.tgz",
-      "integrity": "sha512-gcBffQRI1soHVAiS4YjfMr3SQ9fC8xVUGMfarTTszU4PjpxyFOknaWoFdt/0rvMeavI9jOtbyvDKAf77cZyYIQ==",
+      "version": "1.0.0-preview.100",
+      "resolved": "https://registry.npmjs.org/@microsoft/kiota-serialization-text/-/kiota-serialization-text-1.0.0-preview.100.tgz",
+      "integrity": "sha512-x2Epz0StHLBkVJKeEmwrXSh6SJuxZ72VVBNO53uHUNZ/Y7X8tZuSQR7X74EO69mEi4zAF21X2jbkF9/dhlARog==",
       "license": "MIT",
       "dependencies": {
-        "@microsoft/kiota-abstractions": "^1.0.0-preview.99",
+        "@microsoft/kiota-abstractions": "^1.0.0-preview.100",
         "tslib": "^2.6.2"
       }
     },
@@ -1318,12 +1308,12 @@
       }
     },
     "node_modules/jsonwebtoken": {
-      "version": "9.0.2",
-      "resolved": "https://registry.npmjs.org/jsonwebtoken/-/jsonwebtoken-9.0.2.tgz",
-      "integrity": "sha512-PRp66vJ865SSqOlgqS8hujT5U4AOgMfhrwYIuIhfKaoSCZcirrmASQr8CX7cUg+RMih+hgznrjp99o+W4pJLHQ==",
+      "version": "9.0.3",
+      "resolved": "https://registry.npmjs.org/jsonwebtoken/-/jsonwebtoken-9.0.3.tgz",
+      "integrity": "sha512-MT/xP0CrubFRNLNKvxJ2BYfy53Zkm++5bX9dtuPbqAeQpTVe0MQTFhao8+Cp//EmJp244xt6Drw/GVEGCUj40g==",
       "license": "MIT",
       "dependencies": {
-        "jws": "^3.2.2",
+        "jws": "^4.0.1",
         "lodash.includes": "^4.3.0",
         "lodash.isboolean": "^3.0.3",
         "lodash.isinteger": "^4.0.4",
@@ -1340,23 +1330,23 @@
       }
     },
     "node_modules/jwa": {
-      "version": "1.4.1",
-      "resolved": "https://registry.npmjs.org/jwa/-/jwa-1.4.1.tgz",
-      "integrity": "sha512-qiLX/xhEEFKUAJ6FiBMbes3w9ATzyk5W7Hvzpa/SLYdxNtng+gcurvrI7TbACjIXlsJyr05/S1oUhZrc63evQA==",
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/jwa/-/jwa-2.0.1.tgz",
+      "integrity": "sha512-hRF04fqJIP8Abbkq5NKGN0Bbr3JxlQ+qhZufXVr0DvujKy93ZCbXZMHDL4EOtodSbCWxOqR8MS1tXA5hwqCXDg==",
       "license": "MIT",
       "dependencies": {
-        "buffer-equal-constant-time": "1.0.1",
+        "buffer-equal-constant-time": "^1.0.1",
         "ecdsa-sig-formatter": "1.0.11",
         "safe-buffer": "^5.0.1"
       }
     },
     "node_modules/jws": {
-      "version": "3.2.2",
-      "resolved": "https://registry.npmjs.org/jws/-/jws-3.2.2.tgz",
-      "integrity": "sha512-YHlZCB6lMTllWDtSPHz/ZXTsi8S00usEV6v1tjq8tOUZzw7DpSDWVXjXDre6ed1w/pd495ODpHZYSdkRTsa0HA==",
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/jws/-/jws-4.0.1.tgz",
+      "integrity": "sha512-EKI/M/yqPncGUUh44xz0PxSidXFr/+r0pA70+gIYhjv+et7yxM+s29Y+VGDkovRofQem0fs7Uvf4+YmAdyRduA==",
       "license": "MIT",
       "dependencies": {
-        "jwa": "^1.4.1",
+        "jwa": "^2.0.1",
         "safe-buffer": "^5.0.1"
       }
     },
@@ -1805,9 +1795,9 @@
       "license": "MIT"
     },
     "node_modules/semver": {
-      "version": "7.7.1",
-      "resolved": "https://registry.npmjs.org/semver/-/semver-7.7.1.tgz",
-      "integrity": "sha512-hlq8tAfn0m/61p4BVRcPzIGr6LKiMwo4VM6dGi6pt4qcRkmNzTcWq6eCEjEh+qXjkMDvPlOFFSGwQjoEa6gyMA==",
+      "version": "7.8.0",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.8.0.tgz",
+      "integrity": "sha512-AcM7dV/5ul4EekoQ29Agm5vri8JNqRyj39o0qpX6vDF2GZrtutZl5RwgD1XnZjiTAfncsJhMI48QQH3sN87YNA==",
       "license": "ISC",
       "bin": {
         "semver": "bin/semver.js"
@@ -2027,15 +2017,6 @@
       "integrity": "sha512-Zz+aZWSj8LE6zoxD+xrjh4VfkIG8Ya6LvYkZqtUQGJPZjYl53ypCaUwWqo7eI0x66KBGeRo+mlBEkMSeSZ38Nw==",
       "dev": true,
       "license": "MIT"
-    },
-    "node_modules/uuid": {
-      "version": "8.3.2",
-      "resolved": "https://registry.npmjs.org/uuid/-/uuid-8.3.2.tgz",
-      "integrity": "sha512-+NYs2QeMWy+GWFOEm9xnn6HCDp0l7QBD7ml8zLUmJ+93Q5NF0NocErnwkTkXVFNiX3/fpC6afS8Dhb/gz7R7eg==",
-      "license": "MIT",
-      "bin": {
-        "uuid": "dist/bin/uuid"
-      }
     },
     "node_modules/which": {
       "version": "2.0.2",
@@ -2273,20 +2254,20 @@
     },
     "packages/msgraph-sdk": {
       "name": "@microsoft/msgraph-sdk",
-      "version": "1.0.0-preview.79",
+      "version": "1.0.0-preview.82",
       "license": "MIT",
       "dependencies": {
         "@microsoft/msgraph-sdk-core": "^1.0.0-preview.17",
         "tslib": "^2.6.2"
       },
       "devDependencies": {
-        "@types/node": "^25.2.3",
+        "@types/node": "^25.0.10",
         "typescript": "^5.3.3"
       }
     },
     "packages/msgraph-sdk-admin": {
       "name": "@microsoft/msgraph-sdk-admin",
-      "version": "1.0.0-preview.79",
+      "version": "1.0.0-preview.82",
       "license": "MIT",
       "dependencies": {
         "@microsoft/msgraph-sdk": "^1.0.0-preview.42",
@@ -2298,7 +2279,7 @@
     },
     "packages/msgraph-sdk-agreementAcceptances": {
       "name": "@microsoft/msgraph-sdk-agreementacceptances",
-      "version": "1.0.0-preview.79",
+      "version": "1.0.0-preview.82",
       "license": "MIT",
       "dependencies": {
         "@microsoft/msgraph-sdk": "^1.0.0-preview.42",
@@ -2310,7 +2291,7 @@
     },
     "packages/msgraph-sdk-agreements": {
       "name": "@microsoft/msgraph-sdk-agreements",
-      "version": "1.0.0-preview.79",
+      "version": "1.0.0-preview.82",
       "license": "MIT",
       "dependencies": {
         "@microsoft/msgraph-sdk": "^1.0.0-preview.42",
@@ -2322,7 +2303,7 @@
     },
     "packages/msgraph-sdk-appCatalogs": {
       "name": "@microsoft/msgraph-sdk-appcatalogs",
-      "version": "1.0.0-preview.79",
+      "version": "1.0.0-preview.82",
       "license": "MIT",
       "dependencies": {
         "@microsoft/msgraph-sdk": "^1.0.0-preview.42",
@@ -2334,7 +2315,7 @@
     },
     "packages/msgraph-sdk-applications": {
       "name": "@microsoft/msgraph-sdk-applications",
-      "version": "1.0.0-preview.79",
+      "version": "1.0.0-preview.82",
       "license": "MIT",
       "dependencies": {
         "@microsoft/msgraph-sdk": "^1.0.0-preview.42",
@@ -2346,7 +2327,7 @@
     },
     "packages/msgraph-sdk-applicationTemplates": {
       "name": "@microsoft/msgraph-sdk-applicationtemplates",
-      "version": "1.0.0-preview.79",
+      "version": "1.0.0-preview.82",
       "license": "MIT",
       "dependencies": {
         "@microsoft/msgraph-sdk": "^1.0.0-preview.42",
@@ -2358,7 +2339,7 @@
     },
     "packages/msgraph-sdk-auditLogs": {
       "name": "@microsoft/msgraph-sdk-auditlogs",
-      "version": "1.0.0-preview.79",
+      "version": "1.0.0-preview.82",
       "license": "MIT",
       "dependencies": {
         "@microsoft/msgraph-sdk": "^1.0.0-preview.42",
@@ -2370,7 +2351,7 @@
     },
     "packages/msgraph-sdk-authenticationMethodConfigurations": {
       "name": "@microsoft/msgraph-sdk-authenticationmethodconfigurations",
-      "version": "1.0.0-preview.79",
+      "version": "1.0.0-preview.82",
       "license": "MIT",
       "dependencies": {
         "@microsoft/msgraph-sdk": "^1.0.0-preview.42",
@@ -2382,7 +2363,7 @@
     },
     "packages/msgraph-sdk-authenticationMethodsPolicy": {
       "name": "@microsoft/msgraph-sdk-authenticationmethodspolicy",
-      "version": "1.0.0-preview.79",
+      "version": "1.0.0-preview.82",
       "license": "MIT",
       "dependencies": {
         "@microsoft/msgraph-sdk": "^1.0.0-preview.42",
@@ -2394,7 +2375,7 @@
     },
     "packages/msgraph-sdk-certificateBasedAuthConfiguration": {
       "name": "@microsoft/msgraph-sdk-certificatebasedauthconfiguration",
-      "version": "1.0.0-preview.79",
+      "version": "1.0.0-preview.82",
       "license": "MIT",
       "dependencies": {
         "@microsoft/msgraph-sdk": "^1.0.0-preview.42",
@@ -2406,7 +2387,7 @@
     },
     "packages/msgraph-sdk-chats": {
       "name": "@microsoft/msgraph-sdk-chats",
-      "version": "1.0.0-preview.79",
+      "version": "1.0.0-preview.82",
       "license": "MIT",
       "dependencies": {
         "@microsoft/msgraph-sdk": "^1.0.0-preview.42",
@@ -2418,7 +2399,7 @@
     },
     "packages/msgraph-sdk-communications": {
       "name": "@microsoft/msgraph-sdk-communications",
-      "version": "1.0.0-preview.79",
+      "version": "1.0.0-preview.82",
       "license": "MIT",
       "dependencies": {
         "@microsoft/msgraph-sdk": "^1.0.0-preview.42",
@@ -2430,7 +2411,7 @@
     },
     "packages/msgraph-sdk-compliance": {
       "name": "@microsoft/msgraph-sdk-compliance",
-      "version": "1.0.0-preview.79",
+      "version": "1.0.0-preview.82",
       "license": "MIT",
       "dependencies": {
         "@microsoft/msgraph-sdk": "^1.0.0-preview.42",
@@ -2442,7 +2423,7 @@
     },
     "packages/msgraph-sdk-connections": {
       "name": "@microsoft/msgraph-sdk-connections",
-      "version": "1.0.0-preview.79",
+      "version": "1.0.0-preview.82",
       "license": "MIT",
       "dependencies": {
         "@microsoft/msgraph-sdk": "^1.0.0-preview.42",
@@ -2454,7 +2435,7 @@
     },
     "packages/msgraph-sdk-contacts": {
       "name": "@microsoft/msgraph-sdk-contacts",
-      "version": "1.0.0-preview.79",
+      "version": "1.0.0-preview.82",
       "license": "MIT",
       "dependencies": {
         "@microsoft/msgraph-sdk": "^1.0.0-preview.42",
@@ -2466,7 +2447,7 @@
     },
     "packages/msgraph-sdk-contracts": {
       "name": "@microsoft/msgraph-sdk-contracts",
-      "version": "1.0.0-preview.79",
+      "version": "1.0.0-preview.82",
       "license": "MIT",
       "dependencies": {
         "@microsoft/msgraph-sdk": "^1.0.0-preview.42",
@@ -2478,7 +2459,7 @@
     },
     "packages/msgraph-sdk-dataPolicyOperations": {
       "name": "@microsoft/msgraph-sdk-datapolicyoperations",
-      "version": "1.0.0-preview.79",
+      "version": "1.0.0-preview.82",
       "license": "MIT",
       "dependencies": {
         "@microsoft/msgraph-sdk": "^1.0.0-preview.42",
@@ -2490,7 +2471,7 @@
     },
     "packages/msgraph-sdk-deviceAppManagement": {
       "name": "@microsoft/msgraph-sdk-deviceappmanagement",
-      "version": "1.0.0-preview.79",
+      "version": "1.0.0-preview.82",
       "license": "MIT",
       "dependencies": {
         "@microsoft/msgraph-sdk": "^1.0.0-preview.42",
@@ -2502,7 +2483,7 @@
     },
     "packages/msgraph-sdk-deviceManagement": {
       "name": "@microsoft/msgraph-sdk-devicemanagement",
-      "version": "1.0.0-preview.79",
+      "version": "1.0.0-preview.82",
       "license": "MIT",
       "dependencies": {
         "@microsoft/msgraph-sdk": "^1.0.0-preview.42",
@@ -2514,7 +2495,7 @@
     },
     "packages/msgraph-sdk-devices": {
       "name": "@microsoft/msgraph-sdk-devices",
-      "version": "1.0.0-preview.79",
+      "version": "1.0.0-preview.82",
       "license": "MIT",
       "dependencies": {
         "@microsoft/msgraph-sdk": "^1.0.0-preview.42",
@@ -2526,7 +2507,7 @@
     },
     "packages/msgraph-sdk-directory": {
       "name": "@microsoft/msgraph-sdk-directory",
-      "version": "1.0.0-preview.79",
+      "version": "1.0.0-preview.82",
       "license": "MIT",
       "dependencies": {
         "@microsoft/msgraph-sdk": "^1.0.0-preview.42",
@@ -2538,7 +2519,7 @@
     },
     "packages/msgraph-sdk-directoryObjects": {
       "name": "@microsoft/msgraph-sdk-directoryobjects",
-      "version": "1.0.0-preview.79",
+      "version": "1.0.0-preview.82",
       "license": "MIT",
       "dependencies": {
         "@microsoft/msgraph-sdk": "^1.0.0-preview.42",
@@ -2550,7 +2531,7 @@
     },
     "packages/msgraph-sdk-directoryRoles": {
       "name": "@microsoft/msgraph-sdk-directoryroles",
-      "version": "1.0.0-preview.79",
+      "version": "1.0.0-preview.82",
       "license": "MIT",
       "dependencies": {
         "@microsoft/msgraph-sdk": "^1.0.0-preview.42",
@@ -2562,7 +2543,7 @@
     },
     "packages/msgraph-sdk-directoryRoleTemplates": {
       "name": "@microsoft/msgraph-sdk-directoryroletemplates",
-      "version": "1.0.0-preview.79",
+      "version": "1.0.0-preview.82",
       "license": "MIT",
       "dependencies": {
         "@microsoft/msgraph-sdk": "^1.0.0-preview.42",
@@ -2574,7 +2555,7 @@
     },
     "packages/msgraph-sdk-domainDnsRecords": {
       "name": "@microsoft/msgraph-sdk-domaindnsrecords",
-      "version": "1.0.0-preview.79",
+      "version": "1.0.0-preview.82",
       "license": "MIT",
       "dependencies": {
         "@microsoft/msgraph-sdk": "^1.0.0-preview.42",
@@ -2586,7 +2567,7 @@
     },
     "packages/msgraph-sdk-domains": {
       "name": "@microsoft/msgraph-sdk-domains",
-      "version": "1.0.0-preview.79",
+      "version": "1.0.0-preview.82",
       "license": "MIT",
       "dependencies": {
         "@microsoft/msgraph-sdk": "^1.0.0-preview.42",
@@ -2598,7 +2579,7 @@
     },
     "packages/msgraph-sdk-drives": {
       "name": "@microsoft/msgraph-sdk-drives",
-      "version": "1.0.0-preview.79",
+      "version": "1.0.0-preview.82",
       "license": "MIT",
       "dependencies": {
         "@microsoft/msgraph-sdk": "^1.0.0-preview.42",
@@ -2610,7 +2591,7 @@
     },
     "packages/msgraph-sdk-education": {
       "name": "@microsoft/msgraph-sdk-education",
-      "version": "1.0.0-preview.79",
+      "version": "1.0.0-preview.82",
       "license": "MIT",
       "dependencies": {
         "@microsoft/msgraph-sdk": "^1.0.0-preview.42",
@@ -2622,7 +2603,7 @@
     },
     "packages/msgraph-sdk-employeeExperience": {
       "name": "@microsoft/msgraph-sdk-employeeexperience",
-      "version": "1.0.0-preview.79",
+      "version": "1.0.0-preview.82",
       "license": "MIT",
       "dependencies": {
         "@microsoft/msgraph-sdk": "^1.0.0-preview.42",
@@ -2634,7 +2615,7 @@
     },
     "packages/msgraph-sdk-external": {
       "name": "@microsoft/msgraph-sdk-external",
-      "version": "1.0.0-preview.79",
+      "version": "1.0.0-preview.82",
       "license": "MIT",
       "dependencies": {
         "@microsoft/msgraph-sdk": "^1.0.0-preview.42",
@@ -2646,7 +2627,7 @@
     },
     "packages/msgraph-sdk-filterOperators": {
       "name": "@microsoft/msgraph-sdk-filteroperators",
-      "version": "1.0.0-preview.79",
+      "version": "1.0.0-preview.82",
       "license": "MIT",
       "dependencies": {
         "@microsoft/msgraph-sdk": "^1.0.0-preview.42",
@@ -2658,7 +2639,7 @@
     },
     "packages/msgraph-sdk-functions": {
       "name": "@microsoft/msgraph-sdk-functions",
-      "version": "1.0.0-preview.79",
+      "version": "1.0.0-preview.82",
       "license": "MIT",
       "dependencies": {
         "@microsoft/msgraph-sdk": "^1.0.0-preview.42",
@@ -2670,7 +2651,7 @@
     },
     "packages/msgraph-sdk-groupLifecyclePolicies": {
       "name": "@microsoft/msgraph-sdk-grouplifecyclepolicies",
-      "version": "1.0.0-preview.79",
+      "version": "1.0.0-preview.82",
       "license": "MIT",
       "dependencies": {
         "@microsoft/msgraph-sdk": "^1.0.0-preview.42",
@@ -2682,7 +2663,7 @@
     },
     "packages/msgraph-sdk-groups": {
       "name": "@microsoft/msgraph-sdk-groups",
-      "version": "1.0.0-preview.79",
+      "version": "1.0.0-preview.82",
       "license": "MIT",
       "dependencies": {
         "@microsoft/msgraph-sdk": "^1.0.0-preview.42",
@@ -2694,7 +2675,7 @@
     },
     "packages/msgraph-sdk-groupSettings": {
       "name": "@microsoft/msgraph-sdk-groupsettings",
-      "version": "1.0.0-preview.79",
+      "version": "1.0.0-preview.82",
       "license": "MIT",
       "dependencies": {
         "@microsoft/msgraph-sdk": "^1.0.0-preview.42",
@@ -2706,7 +2687,7 @@
     },
     "packages/msgraph-sdk-groupSettingTemplates": {
       "name": "@microsoft/msgraph-sdk-groupsettingtemplates",
-      "version": "1.0.0-preview.79",
+      "version": "1.0.0-preview.82",
       "license": "MIT",
       "dependencies": {
         "@microsoft/msgraph-sdk": "^1.0.0-preview.42",
@@ -2718,7 +2699,7 @@
     },
     "packages/msgraph-sdk-identity": {
       "name": "@microsoft/msgraph-sdk-identity",
-      "version": "1.0.0-preview.79",
+      "version": "1.0.0-preview.82",
       "license": "MIT",
       "dependencies": {
         "@microsoft/msgraph-sdk": "^1.0.0-preview.42",
@@ -2730,7 +2711,7 @@
     },
     "packages/msgraph-sdk-identityGovernance": {
       "name": "@microsoft/msgraph-sdk-identitygovernance",
-      "version": "1.0.0-preview.79",
+      "version": "1.0.0-preview.82",
       "license": "MIT",
       "dependencies": {
         "@microsoft/msgraph-sdk": "^1.0.0-preview.42",
@@ -2742,7 +2723,7 @@
     },
     "packages/msgraph-sdk-identityProtection": {
       "name": "@microsoft/msgraph-sdk-identityprotection",
-      "version": "1.0.0-preview.79",
+      "version": "1.0.0-preview.82",
       "license": "MIT",
       "dependencies": {
         "@microsoft/msgraph-sdk": "^1.0.0-preview.42",
@@ -2754,7 +2735,7 @@
     },
     "packages/msgraph-sdk-identityProviders": {
       "name": "@microsoft/msgraph-sdk-identityproviders",
-      "version": "1.0.0-preview.79",
+      "version": "1.0.0-preview.82",
       "license": "MIT",
       "dependencies": {
         "@microsoft/msgraph-sdk": "^1.0.0-preview.42",
@@ -2766,7 +2747,7 @@
     },
     "packages/msgraph-sdk-informationProtection": {
       "name": "@microsoft/msgraph-sdk-informationprotection",
-      "version": "1.0.0-preview.79",
+      "version": "1.0.0-preview.82",
       "license": "MIT",
       "dependencies": {
         "@microsoft/msgraph-sdk": "^1.0.0-preview.42",
@@ -2778,7 +2759,7 @@
     },
     "packages/msgraph-sdk-invitations": {
       "name": "@microsoft/msgraph-sdk-invitations",
-      "version": "1.0.0-preview.79",
+      "version": "1.0.0-preview.82",
       "license": "MIT",
       "dependencies": {
         "@microsoft/msgraph-sdk": "^1.0.0-preview.42",
@@ -2790,7 +2771,7 @@
     },
     "packages/msgraph-sdk-oauth2PermissionGrants": {
       "name": "@microsoft/msgraph-sdk-oauth2permissiongrants",
-      "version": "1.0.0-preview.79",
+      "version": "1.0.0-preview.82",
       "license": "MIT",
       "dependencies": {
         "@microsoft/msgraph-sdk": "^1.0.0-preview.42",
@@ -2802,7 +2783,7 @@
     },
     "packages/msgraph-sdk-organization": {
       "name": "@microsoft/msgraph-sdk-organization",
-      "version": "1.0.0-preview.79",
+      "version": "1.0.0-preview.82",
       "license": "MIT",
       "dependencies": {
         "@microsoft/msgraph-sdk": "^1.0.0-preview.42",
@@ -2814,7 +2795,7 @@
     },
     "packages/msgraph-sdk-permissionGrants": {
       "name": "@microsoft/msgraph-sdk-permissiongrants",
-      "version": "1.0.0-preview.79",
+      "version": "1.0.0-preview.82",
       "license": "MIT",
       "dependencies": {
         "@microsoft/msgraph-sdk": "^1.0.0-preview.42",
@@ -2826,7 +2807,7 @@
     },
     "packages/msgraph-sdk-places": {
       "name": "@microsoft/msgraph-sdk-places",
-      "version": "1.0.0-preview.79",
+      "version": "1.0.0-preview.82",
       "license": "MIT",
       "dependencies": {
         "@microsoft/msgraph-sdk": "^1.0.0-preview.42",
@@ -2838,7 +2819,7 @@
     },
     "packages/msgraph-sdk-planner": {
       "name": "@microsoft/msgraph-sdk-planner",
-      "version": "1.0.0-preview.79",
+      "version": "1.0.0-preview.82",
       "license": "MIT",
       "dependencies": {
         "@microsoft/msgraph-sdk": "^1.0.0-preview.42",
@@ -2850,7 +2831,7 @@
     },
     "packages/msgraph-sdk-policies": {
       "name": "@microsoft/msgraph-sdk-policies",
-      "version": "1.0.0-preview.79",
+      "version": "1.0.0-preview.82",
       "license": "MIT",
       "dependencies": {
         "@microsoft/msgraph-sdk": "^1.0.0-preview.42",
@@ -2862,7 +2843,7 @@
     },
     "packages/msgraph-sdk-print": {
       "name": "@microsoft/msgraph-sdk-print",
-      "version": "1.0.0-preview.79",
+      "version": "1.0.0-preview.82",
       "license": "MIT",
       "dependencies": {
         "@microsoft/msgraph-sdk": "^1.0.0-preview.42",
@@ -2874,7 +2855,7 @@
     },
     "packages/msgraph-sdk-privacy": {
       "name": "@microsoft/msgraph-sdk-privacy",
-      "version": "1.0.0-preview.79",
+      "version": "1.0.0-preview.82",
       "license": "MIT",
       "dependencies": {
         "@microsoft/msgraph-sdk": "^1.0.0-preview.42",
@@ -2886,7 +2867,7 @@
     },
     "packages/msgraph-sdk-reports": {
       "name": "@microsoft/msgraph-sdk-reports",
-      "version": "1.0.0-preview.79",
+      "version": "1.0.0-preview.82",
       "license": "MIT",
       "dependencies": {
         "@microsoft/msgraph-sdk": "^1.0.0-preview.42",
@@ -2898,7 +2879,7 @@
     },
     "packages/msgraph-sdk-roleManagement": {
       "name": "@microsoft/msgraph-sdk-rolemanagement",
-      "version": "1.0.0-preview.79",
+      "version": "1.0.0-preview.82",
       "license": "MIT",
       "dependencies": {
         "@microsoft/msgraph-sdk": "^1.0.0-preview.42",
@@ -2910,7 +2891,7 @@
     },
     "packages/msgraph-sdk-schemaExtensions": {
       "name": "@microsoft/msgraph-sdk-schemaextensions",
-      "version": "1.0.0-preview.79",
+      "version": "1.0.0-preview.82",
       "license": "MIT",
       "dependencies": {
         "@microsoft/msgraph-sdk": "^1.0.0-preview.42",
@@ -2922,7 +2903,7 @@
     },
     "packages/msgraph-sdk-scopedRoleMemberships": {
       "name": "@microsoft/msgraph-sdk-scopedrolememberships",
-      "version": "1.0.0-preview.79",
+      "version": "1.0.0-preview.82",
       "license": "MIT",
       "dependencies": {
         "@microsoft/msgraph-sdk": "^1.0.0-preview.42",
@@ -2934,7 +2915,7 @@
     },
     "packages/msgraph-sdk-search": {
       "name": "@microsoft/msgraph-sdk-search",
-      "version": "1.0.0-preview.79",
+      "version": "1.0.0-preview.82",
       "license": "MIT",
       "dependencies": {
         "@microsoft/msgraph-sdk": "^1.0.0-preview.42",
@@ -2946,7 +2927,7 @@
     },
     "packages/msgraph-sdk-security": {
       "name": "@microsoft/msgraph-sdk-security",
-      "version": "1.0.0-preview.79",
+      "version": "1.0.0-preview.82",
       "license": "MIT",
       "dependencies": {
         "@microsoft/msgraph-sdk": "^1.0.0-preview.42",
@@ -2958,7 +2939,7 @@
     },
     "packages/msgraph-sdk-servicePrincipals": {
       "name": "@microsoft/msgraph-sdk-serviceprincipals",
-      "version": "1.0.0-preview.79",
+      "version": "1.0.0-preview.82",
       "license": "MIT",
       "dependencies": {
         "@microsoft/msgraph-sdk": "^1.0.0-preview.42",
@@ -2970,7 +2951,7 @@
     },
     "packages/msgraph-sdk-shares": {
       "name": "@microsoft/msgraph-sdk-shares",
-      "version": "1.0.0-preview.79",
+      "version": "1.0.0-preview.82",
       "license": "MIT",
       "dependencies": {
         "@microsoft/msgraph-sdk": "^1.0.0-preview.42",
@@ -2982,7 +2963,7 @@
     },
     "packages/msgraph-sdk-sites": {
       "name": "@microsoft/msgraph-sdk-sites",
-      "version": "1.0.0-preview.79",
+      "version": "1.0.0-preview.82",
       "license": "MIT",
       "dependencies": {
         "@microsoft/msgraph-sdk": "^1.0.0-preview.42",
@@ -2994,7 +2975,7 @@
     },
     "packages/msgraph-sdk-solutions": {
       "name": "@microsoft/msgraph-sdk-solutions",
-      "version": "1.0.0-preview.79",
+      "version": "1.0.0-preview.82",
       "license": "MIT",
       "dependencies": {
         "@microsoft/msgraph-sdk": "^1.0.0-preview.42",
@@ -3006,7 +2987,7 @@
     },
     "packages/msgraph-sdk-subscribedSkus": {
       "name": "@microsoft/msgraph-sdk-subscribedskus",
-      "version": "1.0.0-preview.79",
+      "version": "1.0.0-preview.82",
       "license": "MIT",
       "dependencies": {
         "@microsoft/msgraph-sdk": "^1.0.0-preview.42",
@@ -3018,7 +2999,7 @@
     },
     "packages/msgraph-sdk-subscriptions": {
       "name": "@microsoft/msgraph-sdk-subscriptions",
-      "version": "1.0.0-preview.79",
+      "version": "1.0.0-preview.82",
       "license": "MIT",
       "dependencies": {
         "@microsoft/msgraph-sdk": "^1.0.0-preview.42",
@@ -3030,7 +3011,7 @@
     },
     "packages/msgraph-sdk-teams": {
       "name": "@microsoft/msgraph-sdk-teams",
-      "version": "1.0.0-preview.79",
+      "version": "1.0.0-preview.82",
       "license": "MIT",
       "dependencies": {
         "@microsoft/msgraph-sdk": "^1.0.0-preview.42",
@@ -3042,7 +3023,7 @@
     },
     "packages/msgraph-sdk-teamsTemplates": {
       "name": "@microsoft/msgraph-sdk-teamstemplates",
-      "version": "1.0.0-preview.79",
+      "version": "1.0.0-preview.82",
       "license": "MIT",
       "dependencies": {
         "@microsoft/msgraph-sdk": "^1.0.0-preview.42",
@@ -3054,7 +3035,7 @@
     },
     "packages/msgraph-sdk-teamwork": {
       "name": "@microsoft/msgraph-sdk-teamwork",
-      "version": "1.0.0-preview.79",
+      "version": "1.0.0-preview.82",
       "license": "MIT",
       "dependencies": {
         "@microsoft/msgraph-sdk": "^1.0.0-preview.42",
@@ -3066,7 +3047,7 @@
     },
     "packages/msgraph-sdk-tenantRelationships": {
       "name": "@microsoft/msgraph-sdk-tenantrelationships",
-      "version": "1.0.0-preview.79",
+      "version": "1.0.0-preview.82",
       "license": "MIT",
       "dependencies": {
         "@microsoft/msgraph-sdk": "^1.0.0-preview.42",
@@ -3078,12 +3059,12 @@
     },
     "packages/msgraph-sdk-tests": {
       "name": "@microsoft/msgraph-sdk-tests",
-      "version": "1.0.0-preview.79",
+      "version": "1.0.0-preview.82",
       "license": "MIT",
       "dependencies": {
-        "@azure/identity": "^4.0.1",
-        "@microsoft/kiota-authentication-azure": "^1.0.0-preview.92",
-        "@microsoft/kiota-bundle": "^1.0.0-preview.92",
+        "@azure/identity": "^4.13.1",
+        "@microsoft/kiota-authentication-azure": "^1.0.0-preview.100",
+        "@microsoft/kiota-bundle": "^1.0.0-preview.100",
         "@microsoft/msgraph-sdk": "^1.0.0-preview.49",
         "@microsoft/msgraph-sdk-core": "^1.0.0-preview.17",
         "@microsoft/msgraph-sdk-users": "^1.0.0-preview.49",
@@ -3092,14 +3073,14 @@
       "devDependencies": {
         "@types/chai": "^5.0.0",
         "@types/mocha": "^10.0.6",
-        "@types/node": "^25.2.3",
+        "@types/node": "^25.0.10",
         "chai": "^6.0.1",
         "mocha": "^11.0.1"
       }
     },
     "packages/msgraph-sdk-users": {
       "name": "@microsoft/msgraph-sdk-users",
-      "version": "1.0.0-preview.79",
+      "version": "1.0.0-preview.82",
       "license": "MIT",
       "dependencies": {
         "@microsoft/msgraph-sdk": "^1.0.0-preview.42",

--- a/packages/msgraph-sdk-tests/package.json
+++ b/packages/msgraph-sdk-tests/package.json
@@ -23,9 +23,9 @@
     "url": "https://github.com/microsoftgraph/msgraph-sdk-typescript/issues"
   },
   "dependencies": {
-    "@azure/identity": "^4.0.1",
-    "@microsoft/kiota-bundle": "^1.0.0-preview.92",
-    "@microsoft/kiota-authentication-azure": "^1.0.0-preview.92",
+    "@azure/identity": "^4.13.1",
+    "@microsoft/kiota-authentication-azure": "^1.0.0-preview.100",
+    "@microsoft/kiota-bundle": "^1.0.0-preview.100",
     "@microsoft/msgraph-sdk": "^1.0.0-preview.49",
     "@microsoft/msgraph-sdk-core": "^1.0.0-preview.17",
     "@microsoft/msgraph-sdk-users": "^1.0.0-preview.49",


### PR DESCRIPTION
Consolidates 6 open dependabot PRs into a single update.

**Dependencies (npm):**
- @azure/identity: 4.13.0 → 4.13.1
- @types/node: 25.2.3 → 25.5.0
- @microsoft/kiota-authentication-azure: 1.0.0-preview.92 → 1.0.0-preview.100
- @microsoft/kiota-bundle: 1.0.0-preview.92 → 1.0.0-preview.100

**GitHub Actions:**
- googleapis/release-please-action: 4 → 5
- dependabot/fetch-metadata: 2.5.0 → 3.1.0
- actions/upload-artifact: 6 → 7

Supersedes #982, #978, #968, #966, #963, #961