### PR TITLE
Update npm dependencies to fix GHSA-396q-4vc8-28x9 Bearer token leak vulnerability

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -27,79 +27,79 @@
       }
     },
     "node_modules/@azure/core-auth": {
-      "version": "1.9.0",
-      "resolved": "https://registry.npmjs.org/@azure/core-auth/-/core-auth-1.9.0.tgz",
-      "integrity": "sha512-FPwHpZywuyasDSLMqJ6fhbOK3TqUdviZNF8OqRGA4W5Ewib2lEEZ+pBsYcBa88B2NGO/SEnYPGhyBqNlE8ilSw==",
+      "version": "1.10.1",
+      "resolved": "https://registry.npmjs.org/@azure/core-auth/-/core-auth-1.10.1.tgz",
+      "integrity": "sha512-ykRMW8PjVAn+RS6ww5cmK9U2CyH9p4Q88YJwvUslfuMmN98w/2rdGRLPqJYObapBCdzBVeDgYWdJnFPFb7qzpg==",
       "license": "MIT",
       "dependencies": {
-        "@azure/abort-controller": "^2.0.0",
-        "@azure/core-util": "^1.11.0",
+        "@azure/abort-controller": "^2.1.2",
+        "@azure/core-util": "^1.13.0",
         "tslib": "^2.6.2"
       },
       "engines": {
-        "node": ">=18.0.0"
+        "node": ">=20.0.0"
       }
     },
     "node_modules/@azure/core-client": {
-      "version": "1.9.2",
-      "resolved": "https://registry.npmjs.org/@azure/core-client/-/core-client-1.9.2.tgz",
-      "integrity": "sha512-kRdry/rav3fUKHl/aDLd/pDLcB+4pOFwPPTVEExuMyaI5r+JBbMWqRbCY1pn5BniDaU3lRxO9eaQ1AmSMehl/w==",
+      "version": "1.10.1",
+      "resolved": "https://registry.npmjs.org/@azure/core-client/-/core-client-1.10.1.tgz",
+      "integrity": "sha512-Nh5PhEOeY6PrnxNPsEHRr9eimxLwgLlpmguQaHKBinFYA/RU9+kOYVOQqOrTsCL+KSxrLLl1gD8Dk5BFW/7l/w==",
       "license": "MIT",
       "dependencies": {
-        "@azure/abort-controller": "^2.0.0",
-        "@azure/core-auth": "^1.4.0",
-        "@azure/core-rest-pipeline": "^1.9.1",
-        "@azure/core-tracing": "^1.0.0",
-        "@azure/core-util": "^1.6.1",
-        "@azure/logger": "^1.0.0",
+        "@azure/abort-controller": "^2.1.2",
+        "@azure/core-auth": "^1.10.0",
+        "@azure/core-rest-pipeline": "^1.22.0",
+        "@azure/core-tracing": "^1.3.0",
+        "@azure/core-util": "^1.13.0",
+        "@azure/logger": "^1.3.0",
         "tslib": "^2.6.2"
       },
       "engines": {
-        "node": ">=18.0.0"
+        "node": ">=20.0.0"
       }
     },
     "node_modules/@azure/core-rest-pipeline": {
-      "version": "1.19.0",
-      "resolved": "https://registry.npmjs.org/@azure/core-rest-pipeline/-/core-rest-pipeline-1.19.0.tgz",
-      "integrity": "sha512-bM3308LRyg5g7r3Twprtqww0R/r7+GyVxj4BafcmVPo4WQoGt5JXuaqxHEFjw2o3rvFZcUPiqJMg6WuvEEeVUA==",
+      "version": "1.23.0",
+      "resolved": "https://registry.npmjs.org/@azure/core-rest-pipeline/-/core-rest-pipeline-1.23.0.tgz",
+      "integrity": "sha512-Evs1INHo+jUjwHi1T6SG6Ua/LHOQBCLuKEEE6efIpt4ZOoNonaT1kP32GoOcdNDbfqsD2445CPri3MubBy5DEQ==",
       "license": "MIT",
       "dependencies": {
-        "@azure/abort-controller": "^2.0.0",
-        "@azure/core-auth": "^1.8.0",
-        "@azure/core-tracing": "^1.0.1",
-        "@azure/core-util": "^1.11.0",
-        "@azure/logger": "^1.0.0",
-        "http-proxy-agent": "^7.0.0",
-        "https-proxy-agent": "^7.0.0",
+        "@azure/abort-controller": "^2.1.2",
+        "@azure/core-auth": "^1.10.0",
+        "@azure/core-tracing": "^1.3.0",
+        "@azure/core-util": "^1.13.0",
+        "@azure/logger": "^1.3.0",
+        "@typespec/ts-http-runtime": "^0.3.4",
         "tslib": "^2.6.2"
       },
       "engines": {
-        "node": ">=18.0.0"
+        "node": ">=20.0.0"
       }
     },
     "node_modules/@azure/core-tracing": {
-      "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/@azure/core-tracing/-/core-tracing-1.2.0.tgz",
-      "integrity": "sha512-UKTiEJPkWcESPYJz3X5uKRYyOcJD+4nYph+KpfdPRnQJVrZfk0KJgdnaAWKfhsBBtAf/D58Az4AvCJEmWgIBAg==",
+      "version": "1.3.1",
+      "resolved": "https://registry.npmjs.org/@azure/core-tracing/-/core-tracing-1.3.1.tgz",
+      "integrity": "sha512-9MWKevR7Hz8kNzzPLfX4EAtGM2b8mr50HPDBvio96bURP/9C+HjdH3sBlLSNNrvRAr5/k/svoH457gB5IKpmwQ==",
       "license": "MIT",
       "dependencies": {
         "tslib": "^2.6.2"
       },
       "engines": {
-        "node": ">=18.0.0"
+        "node": ">=20.0.0"
       }
     },
     "node_modules/@azure/core-util": {
-      "version": "1.11.0",
-      "resolved": "https://registry.npmjs.org/@azure/core-util/-/core-util-1.11.0.tgz",
-      "integrity": "sha512-DxOSLua+NdpWoSqULhjDyAZTXFdP/LKkqtYuxxz1SCN289zk3OG8UOpnCQAz/tygyACBtWp/BoO72ptK7msY8g==",
+      "version": "1.13.1",
+      "resolved": "https://registry.npmjs.org/@azure/core-util/-/core-util-1.13.1.tgz",
+      "integrity": "sha512-XPArKLzsvl0Hf0CaGyKHUyVgF7oDnhKoP85Xv6M4StF/1AhfORhZudHtOyf2s+FcbuQ9dPRAjB8J2KvRRMUK2A==",
       "license": "MIT",
       "dependencies": {
-        "@azure/abort-controller": "^2.0.0",
+        "@azure/abort-controller": "^2.1.2",
+        "@typespec/ts-http-runtime": "^0.3.0",
         "tslib": "^2.6.2"
       },
       "engines": {
-        "node": ">=18.0.0"
+        "node": ">=20.0.0"
       }
     },
     "node_modules/@azure/identity": {
@@ -125,45 +125,46 @@
       }
     },
     "node_modules/@azure/logger": {
-      "version": "1.1.4",
-      "resolved": "https://registry.npmjs.org/@azure/logger/-/logger-1.1.4.tgz",
-      "integrity": "sha512-4IXXzcCdLdlXuCG+8UKEwLA1T1NHqUfanhXYHiQTn+6sfWCZXduqbtXDGceg3Ce5QxTGo7EqmbV6Bi+aqKuClQ==",
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/@azure/logger/-/logger-1.3.0.tgz",
+      "integrity": "sha512-fCqPIfOcLE+CGqGPd66c8bZpwAji98tZ4JI9i/mlTNTlsIWslCfpg48s/ypyLxZTump5sypjrKn2/kY7q8oAbA==",
       "license": "MIT",
       "dependencies": {
+        "@typespec/ts-http-runtime": "^0.3.0",
         "tslib": "^2.6.2"
       },
       "engines": {
-        "node": ">=18.0.0"
+        "node": ">=20.0.0"
       }
     },
     "node_modules/@azure/msal-browser": {
-      "version": "5.10.0",
-      "resolved": "https://registry.npmjs.org/@azure/msal-browser/-/msal-browser-5.10.0.tgz",
-      "integrity": "sha512-2Y4TlG5mCfxviHutfW50i8Xd8xhGKTgieL02vMYOE5ZbZrVM+drKSGD//tweRAmlmqqp+F9vrKoHWri/buzxWQ==",
+      "version": "5.11.0",
+      "resolved": "https://registry.npmjs.org/@azure/msal-browser/-/msal-browser-5.11.0.tgz",
+      "integrity": "sha512-zkGNYS3TwY8lUpPIafAmsFCYZbgFixY9y/LZB9GUg0IILoHTqpN26j5OrkL1AQThh/YdZsawe4iWXfp85lFVxg==",
       "license": "MIT",
       "dependencies": {
-        "@azure/msal-common": "16.6.0"
+        "@azure/msal-common": "16.6.2"
       },
       "engines": {
         "node": ">=0.8.0"
       }
     },
     "node_modules/@azure/msal-common": {
-      "version": "16.6.0",
-      "resolved": "https://registry.npmjs.org/@azure/msal-common/-/msal-common-16.6.0.tgz",
-      "integrity": "sha512-FemGljX0csPlBMUE5GUan7BfRn1emeMRUhHSARhqzLN6LA9nt+MgzmAQ1xVqdLm+6plVoxsq9mS5eoyKtpPSgA==",
+      "version": "16.6.2",
+      "resolved": "https://registry.npmjs.org/@azure/msal-common/-/msal-common-16.6.2.tgz",
+      "integrity": "sha512-hQjjsekAjB00cM1EmatWJlzhEoK2Qhz7Rj5gvM6tYf8iL7RM3tkxlpU9fG0+ofkulzg9AEEA6dIEnSmDr5ZqUA==",
       "license": "MIT",
       "engines": {
         "node": ">=0.8.0"
       }
     },
     "node_modules/@azure/msal-node": {
-      "version": "5.2.0",
-      "resolved": "https://registry.npmjs.org/@azure/msal-node/-/msal-node-5.2.0.tgz",
-      "integrity": "sha512-b/ak8XAqpnGk1N1nsyTVV0Remp48BP3QrGQZ1uCMcvg2S8X1eSXzhHQZEae2oX276Q4KFAqCUswanDtcvIKLrw==",
+      "version": "5.2.2",
+      "resolved": "https://registry.npmjs.org/@azure/msal-node/-/msal-node-5.2.2.tgz",
+      "integrity": "sha512-toS+2AePxqyzb0YOKttDOOiSl3jrkK9aiqIvpurpis0O34QcIS5gToqrgT39p04Dpxw3YoUU0lxJKTpSFFfA6Q==",
       "license": "MIT",
       "dependencies": {
-        "@azure/msal-common": "16.6.0",
+        "@azure/msal-common": "16.6.2",
         "jsonwebtoken": "^9.0.0"
       },
       "engines": {
@@ -188,10 +189,95 @@
         "node": ">=12"
       }
     },
+    "node_modules/@isaacs/cliui/node_modules/ansi-regex": {
+      "version": "6.2.2",
+      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-6.2.2.tgz",
+      "integrity": "sha512-Bq3SmSpyFHaWjPk8If9yc6svM8c56dB5BAtW4Qbw5jHTwwXXcTLoRMkpDJp6VL0XzlWaCHTXrkFURMYmD0sLqg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-regex?sponsor=1"
+      }
+    },
+    "node_modules/@isaacs/cliui/node_modules/ansi-styles": {
+      "version": "6.2.3",
+      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-6.2.3.tgz",
+      "integrity": "sha512-4Dj6M28JB+oAH8kFkTLUo+a2jwOFkuqb3yucU0CANcRRUbxS0cP0nZYCGjcc3BNXwRIsUVmDGgzawme7zvJHvg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
+      }
+    },
+    "node_modules/@isaacs/cliui/node_modules/emoji-regex": {
+      "version": "9.2.2",
+      "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-9.2.2.tgz",
+      "integrity": "sha512-L18DaJsXSUk2+42pv8mLs5jJT2hqFkFE4j21wOmgbUqsZ2hL72NsUU785g9RXgo3s0ZNgVl42TiHp3ZtOv/Vyg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@isaacs/cliui/node_modules/string-width": {
+      "version": "5.1.2",
+      "resolved": "https://registry.npmjs.org/string-width/-/string-width-5.1.2.tgz",
+      "integrity": "sha512-HnLOCR3vjcY8beoNLtcjZ5/nxn2afmME6lhrDrebokqMap+XbeW8n9TXpPDOqdGK5qcI3oT0GKTW6wC7EMiVqA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "eastasianwidth": "^0.2.0",
+        "emoji-regex": "^9.2.2",
+        "strip-ansi": "^7.0.1"
+      },
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/@isaacs/cliui/node_modules/strip-ansi": {
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-7.2.0.tgz",
+      "integrity": "sha512-yDPMNjp4WyfYBkHnjIRLfca1i6KMyGCtsVgoKe/z1+6vukgaENdgGBZt+ZmKPc4gavvEZ5OgHfHdrazhgNyG7w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ansi-regex": "^6.2.2"
+      },
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/strip-ansi?sponsor=1"
+      }
+    },
+    "node_modules/@isaacs/cliui/node_modules/wrap-ansi": {
+      "version": "8.1.0",
+      "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-8.1.0.tgz",
+      "integrity": "sha512-si7QWI6zUMq56bESFvagtmzMdGOtoxfR+Sez11Mobfc7tm+VkUckk9bW2UeffTGVUbOksxmSw0AA2gs8g71NCQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ansi-styles": "^6.1.0",
+        "string-width": "^5.0.1",
+        "strip-ansi": "^7.0.1"
+      },
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/wrap-ansi?sponsor=1"
+      }
+    },
     "node_modules/@microsoft/kiota-abstractions": {
-      "version": "1.0.0-preview.100",
-      "resolved": "https://registry.npmjs.org/@microsoft/kiota-abstractions/-/kiota-abstractions-1.0.0-preview.100.tgz",
-      "integrity": "sha512-3s2WYKQ6WLB/0pyDmmv9bigH/3LZ0Mm4ldHskNLBj0U8DYjFzfG729snnEij+hZN0l2XHr37pGBr1MZK8vM7zQ==",
+      "version": "1.0.0-preview.102",
+      "resolved": "https://registry.npmjs.org/@microsoft/kiota-abstractions/-/kiota-abstractions-1.0.0-preview.102.tgz",
+      "integrity": "sha512-WL+S7X+W6zpDO6vFk+FClb5hoUJMV1ZcMHo1H52r2Q49xTuYx9esJqmwh/0EXsftmxKwOOIOoPfO7+Tp5QAddw==",
       "license": "MIT",
       "dependencies": {
         "@opentelemetry/api": "^1.7.0",
@@ -201,79 +287,79 @@
       }
     },
     "node_modules/@microsoft/kiota-authentication-azure": {
-      "version": "1.0.0-preview.100",
-      "resolved": "https://registry.npmjs.org/@microsoft/kiota-authentication-azure/-/kiota-authentication-azure-1.0.0-preview.100.tgz",
-      "integrity": "sha512-RT6LtekPVaFYQ5JHOiMDrYEdsx6RyiRtoGz929m3iy+jS6W2dELWTO4mrtAG3Q+8Tczk1uUwP21tYy/Wyf07lw==",
+      "version": "1.0.0-preview.102",
+      "resolved": "https://registry.npmjs.org/@microsoft/kiota-authentication-azure/-/kiota-authentication-azure-1.0.0-preview.102.tgz",
+      "integrity": "sha512-S+TENSTiMNI0KfXZeuuN0bQEpSOYPYviz/KiiiwByx9M96aoF/Oxagj8PoCVebbJRxrVkZrRsVyRuKt0ikfyDw==",
       "license": "MIT",
       "dependencies": {
         "@azure/core-auth": "^1.5.0",
-        "@microsoft/kiota-abstractions": "^1.0.0-preview.100",
+        "@microsoft/kiota-abstractions": "^1.0.0-preview.102",
         "@opentelemetry/api": "^1.7.0",
         "tslib": "^2.6.2"
       }
     },
     "node_modules/@microsoft/kiota-bundle": {
-      "version": "1.0.0-preview.100",
-      "resolved": "https://registry.npmjs.org/@microsoft/kiota-bundle/-/kiota-bundle-1.0.0-preview.100.tgz",
-      "integrity": "sha512-ejYzO9Fku/d5IyYYegdQbMQy9cJd8O9HT8TIUA3Ty/39bzNrGG5b6MltKwqr134jTbfMjraaRmh9wD8p246lhA==",
+      "version": "1.0.0-preview.102",
+      "resolved": "https://registry.npmjs.org/@microsoft/kiota-bundle/-/kiota-bundle-1.0.0-preview.102.tgz",
+      "integrity": "sha512-9Y8lTN6Az9Os+TbSyMxkOOMVObtslHrz5C2ohYmZ0dvbINpJskPu2K3StT6PgF0WTCVpyoxlCCYJUSoXdG4/HA==",
       "license": "MIT",
       "dependencies": {
-        "@microsoft/kiota-abstractions": "^1.0.0-preview.100",
-        "@microsoft/kiota-http-fetchlibrary": "^1.0.0-preview.100",
-        "@microsoft/kiota-serialization-form": "^1.0.0-preview.100",
-        "@microsoft/kiota-serialization-json": "^1.0.0-preview.100",
-        "@microsoft/kiota-serialization-multipart": "^1.0.0-preview.100",
-        "@microsoft/kiota-serialization-text": "^1.0.0-preview.100"
+        "@microsoft/kiota-abstractions": "^1.0.0-preview.102",
+        "@microsoft/kiota-http-fetchlibrary": "^1.0.0-preview.102",
+        "@microsoft/kiota-serialization-form": "^1.0.0-preview.102",
+        "@microsoft/kiota-serialization-json": "^1.0.0-preview.102",
+        "@microsoft/kiota-serialization-multipart": "^1.0.0-preview.102",
+        "@microsoft/kiota-serialization-text": "^1.0.0-preview.102"
       }
     },
     "node_modules/@microsoft/kiota-http-fetchlibrary": {
-      "version": "1.0.0-preview.100",
-      "resolved": "https://registry.npmjs.org/@microsoft/kiota-http-fetchlibrary/-/kiota-http-fetchlibrary-1.0.0-preview.100.tgz",
-      "integrity": "sha512-uS2rhKKjbYiT8JWG8GGVOALB+s4HdDc9hg5tTZMVf3qY5b/us1OKLQ6WgW6USq/kZAuKKWkIq/BQgPCWbHtFTQ==",
+      "version": "1.0.0-preview.102",
+      "resolved": "https://registry.npmjs.org/@microsoft/kiota-http-fetchlibrary/-/kiota-http-fetchlibrary-1.0.0-preview.102.tgz",
+      "integrity": "sha512-oXfrPOWkIR2/Gs700n00EY3VDc+Qgz6y7ZiA/f8FHJsnwSjZ017xcWFw2PLzJItczVsad0pq/N5DYnoF6Co11Q==",
       "license": "MIT",
       "dependencies": {
-        "@microsoft/kiota-abstractions": "^1.0.0-preview.100",
+        "@microsoft/kiota-abstractions": "^1.0.0-preview.102",
         "@opentelemetry/api": "^1.7.0",
         "tslib": "^2.6.2"
       }
     },
     "node_modules/@microsoft/kiota-serialization-form": {
-      "version": "1.0.0-preview.100",
-      "resolved": "https://registry.npmjs.org/@microsoft/kiota-serialization-form/-/kiota-serialization-form-1.0.0-preview.100.tgz",
-      "integrity": "sha512-SR/yWBtvKYhN2ARR4wVMFb91XgN32DBmLLQmtemdKgL1YWBxVCNAUP/qHbZhrTX7q4kh7jl/S9yrr1S8ySS7AA==",
+      "version": "1.0.0-preview.102",
+      "resolved": "https://registry.npmjs.org/@microsoft/kiota-serialization-form/-/kiota-serialization-form-1.0.0-preview.102.tgz",
+      "integrity": "sha512-1w70XAA/F4RgbyNbRAaZCjLAOiKQjdiQDYlNZC9x8g7xgd7tNqYqowt/auQS1A9SZOrT626q6+Gr2xKKyW3wOg==",
       "license": "MIT",
       "dependencies": {
-        "@microsoft/kiota-abstractions": "^1.0.0-preview.100",
+        "@microsoft/kiota-abstractions": "^1.0.0-preview.102",
         "tslib": "^2.6.2"
       }
     },
     "node_modules/@microsoft/kiota-serialization-json": {
-      "version": "1.0.0-preview.100",
-      "resolved": "https://registry.npmjs.org/@microsoft/kiota-serialization-json/-/kiota-serialization-json-1.0.0-preview.100.tgz",
-      "integrity": "sha512-4qatf5j0Aeaakdw24jMuIX7W6mf/W2rU9UyAjkIrSjaB7W5n8gsUvhoTcRpPTAFN7pvzQkCbO7Z0paRfdYzhIw==",
+      "version": "1.0.0-preview.102",
+      "resolved": "https://registry.npmjs.org/@microsoft/kiota-serialization-json/-/kiota-serialization-json-1.0.0-preview.102.tgz",
+      "integrity": "sha512-YpIt5pXNX13ND736oJFf0wBYPAafCv+CAE17Fa1HcS1drCdXx8ELPQ5GxGDbQG7J5LIMDgUtBOUmf5R/FrMQ6A==",
       "license": "MIT",
       "dependencies": {
-        "@microsoft/kiota-abstractions": "^1.0.0-preview.100",
+        "@microsoft/kiota-abstractions": "^1.0.0-preview.102",
         "tslib": "^2.6.2"
       }
     },
     "node_modules/@microsoft/kiota-serialization-multipart": {
-      "version": "1.0.0-preview.100",
-      "resolved": "https://registry.npmjs.org/@microsoft/kiota-serialization-multipart/-/kiota-serialization-multipart-1.0.0-preview.100.tgz",
-      "integrity": "sha512-zwWoLZH6+KsAl05Ijd8HpbU+mct5wb0//ZCGdCkQ/UqsAaoe2xYSoKicxQbVGv9VvSTq0as7iVLwqDeqEI9rDw==",
+      "version": "1.0.0-preview.102",
+      "resolved": "https://registry.npmjs.org/@microsoft/kiota-serialization-multipart/-/kiota-serialization-multipart-1.0.0-preview.102.tgz",
+      "integrity": "sha512-tjwt0m+8+OqZizZU6gBARTcA8suPYS0onD9IUbhKsvRrAJpBIyp07hnyOTXBgE+gurGGbeT3TTl9AUK2ic6DiA==",
       "license": "MIT",
       "dependencies": {
-        "@microsoft/kiota-abstractions": "^1.0.0-preview.100",
+        "@microsoft/kiota-abstractions": "^1.0.0-preview.102",
         "tslib": "^2.6.2"
       }
     },
     "node_modules/@microsoft/kiota-serialization-text": {
-      "version": "1.0.0-preview.100",
-      "resolved": "https://registry.npmjs.org/@microsoft/kiota-serialization-text/-/kiota-serialization-text-1.0.0-preview.100.tgz",
-      "integrity": "sha512-x2Epz0StHLBkVJKeEmwrXSh6SJuxZ72VVBNO53uHUNZ/Y7X8tZuSQR7X74EO69mEi4zAF21X2jbkF9/dhlARog==",
+      "version": "1.0.0-preview.102",
+      "resolved": "https://registry.npmjs.org/@microsoft/kiota-serialization-text/-/kiota-serialization-text-1.0.0-preview.102.tgz",
+      "integrity": "sha512-ZCihyrXKYGfTz/frqNQvwKsD+EgjhjfclB5/XDrSGNXduisL/f1MbyvjsgmrZnLmtCwX8/v+Mc3vlz716KWYbg==",
       "license": "MIT",
       "dependencies": {
-        "@microsoft/kiota-abstractions": "^1.0.0-preview.100",
+        "@microsoft/kiota-abstractions": "^1.0.0-preview.102",
         "tslib": "^2.6.2"
       }
     },
@@ -566,9 +652,9 @@
       "link": true
     },
     "node_modules/@opentelemetry/api": {
-      "version": "1.9.0",
-      "resolved": "https://registry.npmjs.org/@opentelemetry/api/-/api-1.9.0.tgz",
-      "integrity": "sha512-3giAOQvZiH5F9bMlMiv8+GSPMeqg0dbaeo58/0SlA9sxSqZhnUtxzX9/2FzyhS9sWQf5S0GJE0AKBrFqjpeYcg==",
+      "version": "1.9.1",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/api/-/api-1.9.1.tgz",
+      "integrity": "sha512-gLyJlPHPZYdAk1JENA9LeHejZe1Ti77/pTeFm/nMXmQH/HFZlcS/O2XJB+L8fkbrNSqhdtlvjBVjxwUYanNH5Q==",
       "license": "Apache-2.0",
       "engines": {
         "node": ">=8.0.0"
@@ -586,19 +672,20 @@
       }
     },
     "node_modules/@std-uritemplate/std-uritemplate": {
-      "version": "2.0.3",
-      "resolved": "https://registry.npmjs.org/@std-uritemplate/std-uritemplate/-/std-uritemplate-2.0.3.tgz",
-      "integrity": "sha512-oN5BHB81TMdasLZLkcdmVDFajo3CxrdeYWFKbeVw1MVZcd4jWZX6cbxm0Iq91wt/o2zsJjmefUaYrLInvZ3/DQ==",
+      "version": "2.0.10",
+      "resolved": "https://registry.npmjs.org/@std-uritemplate/std-uritemplate/-/std-uritemplate-2.0.10.tgz",
+      "integrity": "sha512-EGxlaZDK+CcvMYzxLWKgQlhNiyGIoznEi/CVnzM1DCiQQh/EwSH0ThvseXJ4g6btu1hvlUZ70SrZD6ahsglXcw==",
       "license": "Apache-2.0"
     },
     "node_modules/@types/chai": {
-      "version": "5.2.2",
-      "resolved": "https://registry.npmjs.org/@types/chai/-/chai-5.2.2.tgz",
-      "integrity": "sha512-8kB30R7Hwqf40JPiKhVzodJs2Qc1ZJ5zuT3uzw5Hq/dhNCl3G3l83jfpdI1e20BP348+fV7VIL/+FxaXkqBmWg==",
+      "version": "5.2.3",
+      "resolved": "https://registry.npmjs.org/@types/chai/-/chai-5.2.3.tgz",
+      "integrity": "sha512-Mw558oeA9fFbv65/y4mHtXDs9bPnFMZAL/jxdPFUpOHHIXX91mcgEHbS5Lahr+pwZFR8A7GQleRWeI6cGFC2UA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@types/deep-eql": "*"
+        "@types/deep-eql": "*",
+        "assertion-error": "^2.0.1"
       }
     },
     "node_modules/@types/deep-eql": {
@@ -616,45 +703,59 @@
       "license": "MIT"
     },
     "node_modules/@types/node": {
-      "version": "25.9.0",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-25.9.0.tgz",
-      "integrity": "sha512-AOQwYUNolgy3VosiRqXrACUXTN8nJUtPl7FJXMqZVyxiiCLhQuG3jXKvCS1ALr+Y2OmZhzzLVlYPEqJaiqkaJQ==",
+      "version": "25.9.1",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-25.9.1.tgz",
+      "integrity": "sha512-xfrlY7UD5rMJk3ZVJP8BNzS28J36YJg+xp+LPXV1TdWxr8uMH5A860QNxYDGQe/ylDSgjxE52Q9VnO7p75tJxg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "undici-types": ">=7.24.0 <7.24.7"
       }
     },
+    "node_modules/@typespec/ts-http-runtime": {
+      "version": "0.3.5",
+      "resolved": "https://registry.npmjs.org/@typespec/ts-http-runtime/-/ts-http-runtime-0.3.5.tgz",
+      "integrity": "sha512-yURCknZhvywvQItHMMmFSo+fq5arCUIyz/CVk7jD89MSai7dkaX8ufjCWp3NttLojoTVbcE72ri+be/TnEbMHw==",
+      "license": "MIT",
+      "dependencies": {
+        "http-proxy-agent": "^7.0.0",
+        "https-proxy-agent": "^7.0.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
     "node_modules/agent-base": {
-      "version": "7.1.3",
-      "resolved": "https://registry.npmjs.org/agent-base/-/agent-base-7.1.3.tgz",
-      "integrity": "sha512-jRR5wdylq8CkOe6hei19GGZnxM6rBGwFl3Bg0YItGDimvjGtAvdZk4Pu6Cl4u4Igsws4a1fd1Vq3ezrhn4KmFw==",
+      "version": "7.1.4",
+      "resolved": "https://registry.npmjs.org/agent-base/-/agent-base-7.1.4.tgz",
+      "integrity": "sha512-MnA+YT8fwfJPgBx3m60MNqakm30XOkyIoH1y6huTQvC0PwZG7ki8NacLBcrPbNoo8vEZy7Jpuk7+jMO+CUovTQ==",
       "license": "MIT",
       "engines": {
         "node": ">= 14"
       }
     },
     "node_modules/ansi-regex": {
-      "version": "6.1.0",
-      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-6.1.0.tgz",
-      "integrity": "sha512-7HSX4QQb4CspciLpVFwyRe79O3xsIZDDLER21kERQ71oaPodF8jL725AgJMFAYbooIqolJoRLuM81SpeUkpkvA==",
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
+      "integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==",
       "dev": true,
       "license": "MIT",
       "engines": {
-        "node": ">=12"
-      },
-      "funding": {
-        "url": "https://github.com/chalk/ansi-regex?sponsor=1"
+        "node": ">=8"
       }
     },
     "node_modules/ansi-styles": {
-      "version": "6.2.1",
-      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-6.2.1.tgz",
-      "integrity": "sha512-bN798gFfQX+viw3R7yrGWRqnrN2oRkEkUjjl4JNn4E8GxxbjtG3FbrEIIY3l8/hrwUwIeCZvi4QuOTP4MErVug==",
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
+      "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
       "dev": true,
       "license": "MIT",
+      "dependencies": {
+        "color-convert": "^2.0.1"
+      },
       "engines": {
-        "node": ">=12"
+        "node": ">=8"
       },
       "funding": {
         "url": "https://github.com/chalk/ansi-styles?sponsor=1"
@@ -667,21 +768,37 @@
       "dev": true,
       "license": "Python-2.0"
     },
-    "node_modules/balanced-match": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.2.tgz",
-      "integrity": "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==",
+    "node_modules/assertion-error": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/assertion-error/-/assertion-error-2.0.1.tgz",
+      "integrity": "sha512-Izi8RQcffqCeNVgFigKli1ssklIbpHnCYc6AknXGYoB6grJqyeby7jv12JUQgmTAnIDnbck1uxksT4dzN3PWBA==",
       "dev": true,
-      "license": "MIT"
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/balanced-match": {
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-4.0.4.tgz",
+      "integrity": "sha512-BLrgEcRTwX2o6gGxGOCNyMvGSp35YofuYzw9h1IMTRmKqttAZZVU67bdb9Pr2vUHA8+j3i2tJfjO6C6+4myGTA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "18 || 20 || >=22"
+      }
     },
     "node_modules/brace-expansion": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.0.1.tgz",
-      "integrity": "sha512-XnAIvQ8eM+kC6aULx6wuQiwVsnzsi9d3WxzV3FpWTGA19F621kwdbsAcFKXgKUHZWsy+mY6iL1sHTxWEFCytDA==",
+      "version": "5.0.6",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.6.tgz",
+      "integrity": "sha512-kLpxurY4Z4r9sgMsyG0Z9uzsBlgiU/EFKhj/h91/8yHu0edo7XuixOIH3VcJ8kkxs6/jPzoI6U9Vj3WqbMQ94g==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "balanced-match": "^1.0.0"
+        "balanced-match": "^4.0.2"
+      },
+      "engines": {
+        "node": "18 || 20 || >=22"
       }
     },
     "node_modules/browser-stdout": {
@@ -752,22 +869,6 @@
         "url": "https://github.com/chalk/chalk?sponsor=1"
       }
     },
-    "node_modules/chalk/node_modules/ansi-styles": {
-      "version": "4.3.0",
-      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
-      "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "color-convert": "^2.0.1"
-      },
-      "engines": {
-        "node": ">=8"
-      },
-      "funding": {
-        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
-      }
-    },
     "node_modules/chalk/node_modules/supports-color": {
       "version": "7.2.0",
       "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
@@ -812,85 +913,6 @@
         "node": ">=12"
       }
     },
-    "node_modules/cliui/node_modules/ansi-regex": {
-      "version": "5.0.1",
-      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
-      "integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=8"
-      }
-    },
-    "node_modules/cliui/node_modules/ansi-styles": {
-      "version": "4.3.0",
-      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
-      "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "color-convert": "^2.0.1"
-      },
-      "engines": {
-        "node": ">=8"
-      },
-      "funding": {
-        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
-      }
-    },
-    "node_modules/cliui/node_modules/emoji-regex": {
-      "version": "8.0.0",
-      "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-8.0.0.tgz",
-      "integrity": "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==",
-      "dev": true,
-      "license": "MIT"
-    },
-    "node_modules/cliui/node_modules/string-width": {
-      "version": "4.2.3",
-      "resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.3.tgz",
-      "integrity": "sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "emoji-regex": "^8.0.0",
-        "is-fullwidth-code-point": "^3.0.0",
-        "strip-ansi": "^6.0.1"
-      },
-      "engines": {
-        "node": ">=8"
-      }
-    },
-    "node_modules/cliui/node_modules/strip-ansi": {
-      "version": "6.0.1",
-      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
-      "integrity": "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "ansi-regex": "^5.0.1"
-      },
-      "engines": {
-        "node": ">=8"
-      }
-    },
-    "node_modules/cliui/node_modules/wrap-ansi": {
-      "version": "7.0.0",
-      "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-7.0.0.tgz",
-      "integrity": "sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "ansi-styles": "^4.0.0",
-        "string-width": "^4.1.0",
-        "strip-ansi": "^6.0.0"
-      },
-      "engines": {
-        "node": ">=10"
-      },
-      "funding": {
-        "url": "https://github.com/chalk/wrap-ansi?sponsor=1"
-      }
-    },
     "node_modules/color-convert": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
@@ -927,9 +949,9 @@
       }
     },
     "node_modules/debug": {
-      "version": "4.4.0",
-      "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.0.tgz",
-      "integrity": "sha512-6WTZ/IxCY/T6BALoZHaE4ctp9xm+Z5kY/pzYaCHRFeyVhojxlrm+46y68HA6hr0TcwEssoxNiDEUJQjfPZ/RYA==",
+      "version": "4.4.3",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.3.tgz",
+      "integrity": "sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA==",
       "license": "MIT",
       "dependencies": {
         "ms": "^2.1.3"
@@ -957,9 +979,9 @@
       }
     },
     "node_modules/default-browser": {
-      "version": "5.2.1",
-      "resolved": "https://registry.npmjs.org/default-browser/-/default-browser-5.2.1.tgz",
-      "integrity": "sha512-WY/3TUME0x3KPYdRRxEJJvXRHV4PyPoUsxtZa78lwItwRQRHhd2U9xOscaT/YTf8uCXIAjeJOFBVEh/7FtD8Xg==",
+      "version": "5.5.0",
+      "resolved": "https://registry.npmjs.org/default-browser/-/default-browser-5.5.0.tgz",
+      "integrity": "sha512-H9LMLr5zwIbSxrmvikGuI/5KGhZ8E2zH3stkMgM5LpOWDutGM2JZaj460Udnf1a+946zc7YBgrqEWwbk7zHvGw==",
       "license": "MIT",
       "dependencies": {
         "bundle-name": "^4.1.0",
@@ -973,9 +995,9 @@
       }
     },
     "node_modules/default-browser-id": {
-      "version": "5.0.0",
-      "resolved": "https://registry.npmjs.org/default-browser-id/-/default-browser-id-5.0.0.tgz",
-      "integrity": "sha512-A6p/pu/6fyBcA1TRz/GqWYPViplrftcW2gZC9q79ngNCKAeR/X3gcEdXQHl4KNXV+3wgIJ1CPkJQ3IHM6lcsyA==",
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/default-browser-id/-/default-browser-id-5.0.1.tgz",
+      "integrity": "sha512-x1VCxdX4t+8wVfd1so/9w+vQ4vx7lKd2Qp5tDRutErwmR85OgmfX7RlLRMWafRMY7hbEiXIbudNrjOAPa/hL8Q==",
       "license": "MIT",
       "engines": {
         "node": ">=18"
@@ -1023,9 +1045,9 @@
       }
     },
     "node_modules/emoji-regex": {
-      "version": "9.2.2",
-      "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-9.2.2.tgz",
-      "integrity": "sha512-L18DaJsXSUk2+42pv8mLs5jJT2hqFkFE4j21wOmgbUqsZ2hL72NsUU785g9RXgo3s0ZNgVl42TiHp3ZtOv/Vyg==",
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-8.0.0.tgz",
+      "integrity": "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==",
       "dev": true,
       "license": "MIT"
     },
@@ -1107,18 +1129,18 @@
       }
     },
     "node_modules/glob": {
-      "version": "13.0.3",
-      "resolved": "https://registry.npmjs.org/glob/-/glob-13.0.3.tgz",
-      "integrity": "sha512-/g3B0mC+4x724v1TgtBlBtt2hPi/EWptsIAmXUx9Z2rvBYleQcsrmaOzd5LyL50jf/Soi83ZDJmw2+XqvH/EeA==",
+      "version": "13.0.6",
+      "resolved": "https://registry.npmjs.org/glob/-/glob-13.0.6.tgz",
+      "integrity": "sha512-Wjlyrolmm8uDpm/ogGyXZXb1Z+Ca2B8NbJwqBVg0axK9GbBeoS7yGV6vjXnYdGm6X53iehEuxxbyiKp8QmN4Vw==",
       "dev": true,
       "license": "BlueOak-1.0.0",
       "dependencies": {
-        "minimatch": "^10.2.0",
-        "minipass": "^7.1.2",
-        "path-scurry": "^2.0.0"
+        "minimatch": "^10.2.2",
+        "minipass": "^7.1.3",
+        "path-scurry": "^2.0.2"
       },
       "engines": {
-        "node": "20 || >=22"
+        "node": "18 || 20 || >=22"
       },
       "funding": {
         "url": "https://github.com/sponsors/isaacs"
@@ -1247,9 +1269,9 @@
       }
     },
     "node_modules/is-wsl": {
-      "version": "3.1.0",
-      "resolved": "https://registry.npmjs.org/is-wsl/-/is-wsl-3.1.0.tgz",
-      "integrity": "sha512-UcVfVfaK4Sc4m7X3dUSoHoozQGBEFeDC+zVo06t98xe8CzHSZZBekNXH+tu0NalHolcJ/QAGqS46Hef7QXBIMw==",
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/is-wsl/-/is-wsl-3.1.1.tgz",
+      "integrity": "sha512-e6rvdUCiQCAuumZslxRJWR/Doq4VpPR82kqclvcS0efgt430SlGIk05vdCN58+VrzgtIcfNODjozVielycD4Sw==",
       "license": "MIT",
       "dependencies": {
         "is-inside-container": "^1.0.0"
@@ -1269,35 +1291,25 @@
       "license": "ISC"
     },
     "node_modules/jackspeak": {
-      "version": "4.2.3",
-      "resolved": "https://registry.npmjs.org/jackspeak/-/jackspeak-4.2.3.tgz",
-      "integrity": "sha512-ykkVRwrYvFm1nb2AJfKKYPr0emF6IiXDYUaFx4Zn9ZuIH7MrzEZ3sD5RlqGXNRpHtvUHJyOnCEFxOlNDtGo7wg==",
+      "version": "3.4.3",
+      "resolved": "https://registry.npmjs.org/jackspeak/-/jackspeak-3.4.3.tgz",
+      "integrity": "sha512-OGlZQpz2yfahA/Rd1Y8Cd9SIEsqvXkLVoSw/cgwhnhFMDbsQFeZYoJJ7bIZBS9BcamUW96asq/npPWugM+RQBw==",
       "dev": true,
       "license": "BlueOak-1.0.0",
       "dependencies": {
-        "@isaacs/cliui": "^9.0.0"
-      },
-      "engines": {
-        "node": "20 || >=22"
+        "@isaacs/cliui": "^8.0.2"
       },
       "funding": {
         "url": "https://github.com/sponsors/isaacs"
-      }
-    },
-    "node_modules/jackspeak/node_modules/@isaacs/cliui": {
-      "version": "9.0.0",
-      "resolved": "https://registry.npmjs.org/@isaacs/cliui/-/cliui-9.0.0.tgz",
-      "integrity": "sha512-AokJm4tuBHillT+FpMtxQ60n8ObyXBatq7jD2/JA9dxbDDokKQm8KMht5ibGzLVU9IJDIKK4TPKgMHEYMn3lMg==",
-      "dev": true,
-      "license": "BlueOak-1.0.0",
-      "engines": {
-        "node": ">=18"
+      },
+      "optionalDependencies": {
+        "@pkgjs/parseargs": "^0.11.0"
       }
     },
     "node_modules/js-yaml": {
-      "version": "4.1.0",
-      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.1.0.tgz",
-      "integrity": "sha512-wpxZs9NoxZaJESJGIZTyDEaYpl0FKSA+FB9aJiyemKhMwkxQg63h4T1KJgUGHpTqPDNRcmmYLugrRjJlBtWvRA==",
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.1.1.tgz",
+      "integrity": "sha512-qQKT4zQxXl8lLwBtHMWwaTcGfFOZviOJet3Oy/xmGk2gZH677CJM9EvtfdSkgWcATZhj/55JZ0rmy3myCT5lsA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -1426,9 +1438,9 @@
       }
     },
     "node_modules/lru-cache": {
-      "version": "11.2.6",
-      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-11.2.6.tgz",
-      "integrity": "sha512-ESL2CrkS/2wTPfuend7Zhkzo2u0daGJ/A2VucJOgQ/C48S/zB8MMeMHSGKYpXhIjbPxfuezITkaBH1wqv00DDQ==",
+      "version": "11.5.0",
+      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-11.5.0.tgz",
+      "integrity": "sha512-5YgH9UJd7wVb9hIouI2adWpgqrrICkt070Dnj8EUY1+B4B2P9eRLPAkAAo6NICA7CEhOIeBHl46u9zSNpNu7zA==",
       "dev": true,
       "license": "BlueOak-1.0.0",
       "engines": {
@@ -1436,61 +1448,35 @@
       }
     },
     "node_modules/minimatch": {
-      "version": "10.2.0",
-      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-10.2.0.tgz",
-      "integrity": "sha512-ugkC31VaVg9cF0DFVoADH12k6061zNZkZON+aX8AWsR9GhPcErkcMBceb6znR8wLERM2AkkOxy2nWRLpT9Jq5w==",
+      "version": "10.2.5",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-10.2.5.tgz",
+      "integrity": "sha512-MULkVLfKGYDFYejP07QOurDLLQpcjk7Fw+7jXS2R2czRQzR56yHRveU5NDJEOviH+hETZKSkIk5c+T23GjFUMg==",
       "dev": true,
       "license": "BlueOak-1.0.0",
       "dependencies": {
-        "brace-expansion": "^5.0.2"
+        "brace-expansion": "^5.0.5"
       },
       "engines": {
-        "node": "20 || >=22"
+        "node": "18 || 20 || >=22"
       },
       "funding": {
         "url": "https://github.com/sponsors/isaacs"
       }
     },
-    "node_modules/minimatch/node_modules/balanced-match": {
-      "version": "4.0.2",
-      "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-4.0.2.tgz",
-      "integrity": "sha512-x0K50QvKQ97fdEz2kPehIerj+YTeptKF9hyYkKf6egnwmMWAkADiO0QCzSp0R5xN8FTZgYaBfSaue46Ej62nMg==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "jackspeak": "^4.2.3"
-      },
-      "engines": {
-        "node": "20 || >=22"
-      }
-    },
-    "node_modules/minimatch/node_modules/brace-expansion": {
-      "version": "5.0.2",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.2.tgz",
-      "integrity": "sha512-Pdk8c9poy+YhOgVWw1JNN22/HcivgKWwpxKq04M/jTmHyCZn12WPJebZxdjSa5TmBqISrUSgNYU3eRORljfCCw==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "balanced-match": "^4.0.2"
-      },
-      "engines": {
-        "node": "20 || >=22"
-      }
-    },
     "node_modules/minipass": {
-      "version": "7.1.2",
-      "resolved": "https://registry.npmjs.org/minipass/-/minipass-7.1.2.tgz",
-      "integrity": "sha512-qOOzS1cBTWYF4BH8fVePDBOO9iptMnGUEZwNc/cMWnTV2nVLZ7VoNWEPHkYczZA0pdoA7dl6e7FL659nX9S2aw==",
+      "version": "7.1.3",
+      "resolved": "https://registry.npmjs.org/minipass/-/minipass-7.1.3.tgz",
+      "integrity": "sha512-tEBHqDnIoM/1rXME1zgka9g6Q2lcoCkxHLuc7ODJ5BxbP5d4c2Z5cGgtXAku59200Cx7diuHTOYfSBD8n6mm8A==",
       "dev": true,
-      "license": "ISC",
+      "license": "BlueOak-1.0.0",
       "engines": {
         "node": ">=16 || 14 >=14.17"
       }
     },
     "node_modules/mocha": {
-      "version": "11.7.5",
-      "resolved": "https://registry.npmjs.org/mocha/-/mocha-11.7.5.tgz",
-      "integrity": "sha512-mTT6RgopEYABzXWFx+GcJ+ZQ32kp4fMf0xvpZIIfSq9Z8lC/++MtcCnQ9t5FP2veYEP95FIYSvW+U9fV4xrlig==",
+      "version": "11.7.6",
+      "resolved": "https://registry.npmjs.org/mocha/-/mocha-11.7.6.tgz",
+      "integrity": "sha512-nS9xOGbw2I3cjCpxwZAEJ9xK9lmJ08vEkQvLtz4du9ZrF9UrjRpeJGiIgl2Z+Qs++pmB4ecDe48Fwsh+j+j7xA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -1524,10 +1510,28 @@
         "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
       }
     },
+    "node_modules/mocha/node_modules/balanced-match": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.2.tgz",
+      "integrity": "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/mocha/node_modules/brace-expansion": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.1.1.tgz",
+      "integrity": "sha512-WR1cURNjuvBLMZBMbqM0UoE+WAfdUcEV1ccD8PVBVOI+Z3ND4+SZbN8RsfT2bMuG1qwz5RFvPukSZm5fF2D5eA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "balanced-match": "^1.0.0"
+      }
+    },
     "node_modules/mocha/node_modules/glob": {
-      "version": "10.4.5",
-      "resolved": "https://registry.npmjs.org/glob/-/glob-10.4.5.tgz",
-      "integrity": "sha512-7Bv8RF0k6xjo7d4A/PxYLbUCfb6c+Vpd2/mB2yRDlew7Jb5hEXiCD9ibfO7wpk8i4sevK6DFny9h7EYbM3/sHg==",
+      "version": "10.5.0",
+      "resolved": "https://registry.npmjs.org/glob/-/glob-10.5.0.tgz",
+      "integrity": "sha512-DfXN8DfhJ7NH3Oe7cFmu3NCu1wKbkReJ8TorzSAFbSKrlNaQSKfIzqYqVY8zlbs2NLBbWpRiU52GX2PbaBVNkg==",
+      "deprecated": "Old versions of glob are not supported, and contain widely publicized security vulnerabilities, which have been fixed in the current version. Please update. Support for old versions may be purchased (at exorbitant rates) by contacting i@izs.me",
       "dev": true,
       "license": "ISC",
       "dependencies": {
@@ -1545,22 +1549,6 @@
         "url": "https://github.com/sponsors/isaacs"
       }
     },
-    "node_modules/mocha/node_modules/jackspeak": {
-      "version": "3.4.3",
-      "resolved": "https://registry.npmjs.org/jackspeak/-/jackspeak-3.4.3.tgz",
-      "integrity": "sha512-OGlZQpz2yfahA/Rd1Y8Cd9SIEsqvXkLVoSw/cgwhnhFMDbsQFeZYoJJ7bIZBS9BcamUW96asq/npPWugM+RQBw==",
-      "dev": true,
-      "license": "BlueOak-1.0.0",
-      "dependencies": {
-        "@isaacs/cliui": "^8.0.2"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/isaacs"
-      },
-      "optionalDependencies": {
-        "@pkgjs/parseargs": "^0.11.0"
-      }
-    },
     "node_modules/mocha/node_modules/lru-cache": {
       "version": "10.4.3",
       "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-10.4.3.tgz",
@@ -1569,13 +1557,13 @@
       "license": "ISC"
     },
     "node_modules/mocha/node_modules/minimatch": {
-      "version": "9.0.5",
-      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-9.0.5.tgz",
-      "integrity": "sha512-G6T0ZX48xgozx7587koeX9Ys2NYy6Gmv//P89sEte9V9whIapMNF4idKxnW2QtCcLiTWlb/wfCabAtAFWhhBow==",
+      "version": "9.0.9",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-9.0.9.tgz",
+      "integrity": "sha512-OBwBN9AL4dqmETlpS2zasx+vTeWclWzkblfZk7KTA5j3jeOONz/tRCnZomUyvNg83wL5Zv9Ss6HMJXAgL8R2Yg==",
       "dev": true,
       "license": "ISC",
       "dependencies": {
-        "brace-expansion": "^2.0.1"
+        "brace-expansion": "^2.0.2"
       },
       "engines": {
         "node": ">=16 || 14 >=14.17"
@@ -1608,15 +1596,15 @@
       "license": "MIT"
     },
     "node_modules/open": {
-      "version": "10.1.0",
-      "resolved": "https://registry.npmjs.org/open/-/open-10.1.0.tgz",
-      "integrity": "sha512-mnkeQ1qP5Ue2wd+aivTD3NHd/lZ96Lu0jgf0pwktLPtx6cTZiH7tyeGRRHs0zX0rbrahXPnXlUnbeXyaBBuIaw==",
+      "version": "10.2.0",
+      "resolved": "https://registry.npmjs.org/open/-/open-10.2.0.tgz",
+      "integrity": "sha512-YgBpdJHPyQ2UE5x+hlSXcnejzAvD0b22U2OuAP+8OnlJT+PjWPxtgmGqKKc+RgTM63U9gN0YzrYc71R2WT/hTA==",
       "license": "MIT",
       "dependencies": {
         "default-browser": "^5.2.1",
         "define-lazy-prop": "^3.0.0",
         "is-inside-container": "^1.0.0",
-        "is-wsl": "^3.1.0"
+        "wsl-utils": "^0.1.0"
       },
       "engines": {
         "node": ">=18"
@@ -1685,9 +1673,9 @@
       }
     },
     "node_modules/path-scurry": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/path-scurry/-/path-scurry-2.0.1.tgz",
-      "integrity": "sha512-oWyT4gICAu+kaA7QWk/jvCHWarMKNs6pXOGWKDTr7cw4IGcUbW+PeTfbaQiLGheFRpjo6O9J0PmyMfQPjH71oA==",
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/path-scurry/-/path-scurry-2.0.2.tgz",
+      "integrity": "sha512-3O/iVVsJAPsOnpwWIeD+d6z/7PmqApyQePUtCndjatj/9I5LylHvt5qluFaBT3I5h3r1ejfR056c+FCv+NnNXg==",
       "dev": true,
       "license": "BlueOak-1.0.0",
       "dependencies": {
@@ -1695,7 +1683,7 @@
         "minipass": "^7.1.2"
       },
       "engines": {
-        "node": "20 || >=22"
+        "node": "18 || 20 || >=22"
       },
       "funding": {
         "url": "https://github.com/sponsors/isaacs"
@@ -1763,9 +1751,9 @@
       }
     },
     "node_modules/run-applescript": {
-      "version": "7.0.0",
-      "resolved": "https://registry.npmjs.org/run-applescript/-/run-applescript-7.0.0.tgz",
-      "integrity": "sha512-9by4Ij99JUr/MCFBUkDKLWK3G9HVXmabKz9U5MlIAIuvuzkiOicRYs8XJLxX+xahD+mLiiCYDqF9dKAgtzKP1A==",
+      "version": "7.1.0",
+      "resolved": "https://registry.npmjs.org/run-applescript/-/run-applescript-7.1.0.tgz",
+      "integrity": "sha512-DPe5pVFaAsinSaV6QjQ6gdiedWDcRCbUuiQfQa2wmWV7+xC9bGulGI8+TdRmoFkAPaBXk8CrAbnlY2ISniJ47Q==",
       "license": "MIT",
       "engines": {
         "node": ">=18"
@@ -1795,9 +1783,9 @@
       "license": "MIT"
     },
     "node_modules/semver": {
-      "version": "7.8.0",
-      "resolved": "https://registry.npmjs.org/semver/-/semver-7.8.0.tgz",
-      "integrity": "sha512-AcM7dV/5ul4EekoQ29Agm5vri8JNqRyj39o0qpX6vDF2GZrtutZl5RwgD1XnZjiTAfncsJhMI48QQH3sN87YNA==",
+      "version": "7.8.1",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.8.1.tgz",
+      "integrity": "sha512-rkVq3IXh+4FDGch+KwzX3aV9W3kO54GyEgpvBzSyctDA6Xtd7RJQV1xmXbeQp5v7+VzLOfVqiutSE6GICgPFvg==",
       "license": "ISC",
       "bin": {
         "semver": "bin/semver.js"
@@ -1853,21 +1841,18 @@
       }
     },
     "node_modules/string-width": {
-      "version": "5.1.2",
-      "resolved": "https://registry.npmjs.org/string-width/-/string-width-5.1.2.tgz",
-      "integrity": "sha512-HnLOCR3vjcY8beoNLtcjZ5/nxn2afmME6lhrDrebokqMap+XbeW8n9TXpPDOqdGK5qcI3oT0GKTW6wC7EMiVqA==",
+      "version": "4.2.3",
+      "resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.3.tgz",
+      "integrity": "sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "eastasianwidth": "^0.2.0",
-        "emoji-regex": "^9.2.2",
-        "strip-ansi": "^7.0.1"
+        "emoji-regex": "^8.0.0",
+        "is-fullwidth-code-point": "^3.0.0",
+        "strip-ansi": "^6.0.1"
       },
       "engines": {
-        "node": ">=12"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
+        "node": ">=8"
       }
     },
     "node_modules/string-width-cjs": {
@@ -1886,24 +1871,7 @@
         "node": ">=8"
       }
     },
-    "node_modules/string-width-cjs/node_modules/ansi-regex": {
-      "version": "5.0.1",
-      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
-      "integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=8"
-      }
-    },
-    "node_modules/string-width-cjs/node_modules/emoji-regex": {
-      "version": "8.0.0",
-      "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-8.0.0.tgz",
-      "integrity": "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==",
-      "dev": true,
-      "license": "MIT"
-    },
-    "node_modules/string-width-cjs/node_modules/strip-ansi": {
+    "node_modules/strip-ansi": {
       "version": "6.0.1",
       "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
       "integrity": "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==",
@@ -1914,22 +1882,6 @@
       },
       "engines": {
         "node": ">=8"
-      }
-    },
-    "node_modules/strip-ansi": {
-      "version": "7.1.0",
-      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-7.1.0.tgz",
-      "integrity": "sha512-iq6eVVI64nQQTRYq2KtEg2d2uU7LElhTJwsH4YzIHZshxlgZms/wIc4VoDQTlG/IvVIrBKG06CrZnp0qv7hkcQ==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "ansi-regex": "^6.0.1"
-      },
-      "engines": {
-        "node": ">=12"
-      },
-      "funding": {
-        "url": "https://github.com/chalk/strip-ansi?sponsor=1"
       }
     },
     "node_modules/strip-ansi-cjs": {
@@ -1942,16 +1894,6 @@
       "dependencies": {
         "ansi-regex": "^5.0.1"
       },
-      "engines": {
-        "node": ">=8"
-      }
-    },
-    "node_modules/strip-ansi-cjs/node_modules/ansi-regex": {
-      "version": "5.0.1",
-      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
-      "integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==",
-      "dev": true,
-      "license": "MIT",
       "engines": {
         "node": ">=8"
       }
@@ -2035,25 +1977,25 @@
       }
     },
     "node_modules/workerpool": {
-      "version": "9.3.2",
-      "resolved": "https://registry.npmjs.org/workerpool/-/workerpool-9.3.2.tgz",
-      "integrity": "sha512-Xz4Nm9c+LiBHhDR5bDLnNzmj6+5F+cyEAWPMkbs2awq/dYazR/efelZzUAjB/y3kNHL+uzkHvxVVpaOfGCPV7A==",
+      "version": "9.3.4",
+      "resolved": "https://registry.npmjs.org/workerpool/-/workerpool-9.3.4.tgz",
+      "integrity": "sha512-TmPRQYYSAnnDiEB0P/Ytip7bFGvqnSU6I2BcuSw7Hx+JSg/DsUi5ebYfc8GYaSdpuvOcEs6dXxPurOYpe9QFwg==",
       "dev": true,
       "license": "Apache-2.0"
     },
     "node_modules/wrap-ansi": {
-      "version": "8.1.0",
-      "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-8.1.0.tgz",
-      "integrity": "sha512-si7QWI6zUMq56bESFvagtmzMdGOtoxfR+Sez11Mobfc7tm+VkUckk9bW2UeffTGVUbOksxmSw0AA2gs8g71NCQ==",
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-7.0.0.tgz",
+      "integrity": "sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "ansi-styles": "^6.1.0",
-        "string-width": "^5.0.1",
-        "strip-ansi": "^7.0.1"
+        "ansi-styles": "^4.0.0",
+        "string-width": "^4.1.0",
+        "strip-ansi": "^6.0.0"
       },
       "engines": {
-        "node": ">=12"
+        "node": ">=10"
       },
       "funding": {
         "url": "https://github.com/chalk/wrap-ansi?sponsor=1"
@@ -2078,65 +2020,19 @@
         "url": "https://github.com/chalk/wrap-ansi?sponsor=1"
       }
     },
-    "node_modules/wrap-ansi-cjs/node_modules/ansi-regex": {
-      "version": "5.0.1",
-      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
-      "integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=8"
-      }
-    },
-    "node_modules/wrap-ansi-cjs/node_modules/ansi-styles": {
-      "version": "4.3.0",
-      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
-      "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
-      "dev": true,
+    "node_modules/wsl-utils": {
+      "version": "0.1.0",
+      "resolved": "https://registry.npmjs.org/wsl-utils/-/wsl-utils-0.1.0.tgz",
+      "integrity": "sha512-h3Fbisa2nKGPxCpm89Hk33lBLsnaGBvctQopaBSOW/uIs6FTe1ATyAnKFJrzVs9vpGdsTe73WF3V4lIsk4Gacw==",
       "license": "MIT",
       "dependencies": {
-        "color-convert": "^2.0.1"
+        "is-wsl": "^3.1.0"
       },
       "engines": {
-        "node": ">=8"
+        "node": ">=18"
       },
       "funding": {
-        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
-      }
-    },
-    "node_modules/wrap-ansi-cjs/node_modules/emoji-regex": {
-      "version": "8.0.0",
-      "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-8.0.0.tgz",
-      "integrity": "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==",
-      "dev": true,
-      "license": "MIT"
-    },
-    "node_modules/wrap-ansi-cjs/node_modules/string-width": {
-      "version": "4.2.3",
-      "resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.3.tgz",
-      "integrity": "sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "emoji-regex": "^8.0.0",
-        "is-fullwidth-code-point": "^3.0.0",
-        "strip-ansi": "^6.0.1"
-      },
-      "engines": {
-        "node": ">=8"
-      }
-    },
-    "node_modules/wrap-ansi-cjs/node_modules/strip-ansi": {
-      "version": "6.0.1",
-      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
-      "integrity": "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "ansi-regex": "^5.0.1"
-      },
-      "engines": {
-        "node": ">=8"
+        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/y18n": {
@@ -2194,51 +2090,6 @@
         "node": ">=10"
       }
     },
-    "node_modules/yargs/node_modules/ansi-regex": {
-      "version": "5.0.1",
-      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
-      "integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=8"
-      }
-    },
-    "node_modules/yargs/node_modules/emoji-regex": {
-      "version": "8.0.0",
-      "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-8.0.0.tgz",
-      "integrity": "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==",
-      "dev": true,
-      "license": "MIT"
-    },
-    "node_modules/yargs/node_modules/string-width": {
-      "version": "4.2.3",
-      "resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.3.tgz",
-      "integrity": "sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "emoji-regex": "^8.0.0",
-        "is-fullwidth-code-point": "^3.0.0",
-        "strip-ansi": "^6.0.1"
-      },
-      "engines": {
-        "node": ">=8"
-      }
-    },
-    "node_modules/yargs/node_modules/strip-ansi": {
-      "version": "6.0.1",
-      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
-      "integrity": "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "ansi-regex": "^5.0.1"
-      },
-      "engines": {
-        "node": ">=8"
-      }
-    },
     "node_modules/yocto-queue": {
       "version": "0.1.0",
       "resolved": "https://registry.npmjs.org/yocto-queue/-/yocto-queue-0.1.0.tgz",
@@ -2254,7 +2105,7 @@
     },
     "packages/msgraph-sdk": {
       "name": "@microsoft/msgraph-sdk",
-      "version": "1.0.0-preview.82",
+      "version": "1.0.0-preview.83",
       "license": "MIT",
       "dependencies": {
         "@microsoft/msgraph-sdk-core": "^1.0.0-preview.17",
@@ -2267,7 +2118,7 @@
     },
     "packages/msgraph-sdk-admin": {
       "name": "@microsoft/msgraph-sdk-admin",
-      "version": "1.0.0-preview.82",
+      "version": "1.0.0-preview.83",
       "license": "MIT",
       "dependencies": {
         "@microsoft/msgraph-sdk": "^1.0.0-preview.42",
@@ -2279,7 +2130,7 @@
     },
     "packages/msgraph-sdk-agreementAcceptances": {
       "name": "@microsoft/msgraph-sdk-agreementacceptances",
-      "version": "1.0.0-preview.82",
+      "version": "1.0.0-preview.83",
       "license": "MIT",
       "dependencies": {
         "@microsoft/msgraph-sdk": "^1.0.0-preview.42",
@@ -2291,7 +2142,7 @@
     },
     "packages/msgraph-sdk-agreements": {
       "name": "@microsoft/msgraph-sdk-agreements",
-      "version": "1.0.0-preview.82",
+      "version": "1.0.0-preview.83",
       "license": "MIT",
       "dependencies": {
         "@microsoft/msgraph-sdk": "^1.0.0-preview.42",
@@ -2303,7 +2154,7 @@
     },
     "packages/msgraph-sdk-appCatalogs": {
       "name": "@microsoft/msgraph-sdk-appcatalogs",
-      "version": "1.0.0-preview.82",
+      "version": "1.0.0-preview.83",
       "license": "MIT",
       "dependencies": {
         "@microsoft/msgraph-sdk": "^1.0.0-preview.42",
@@ -2315,7 +2166,7 @@
     },
     "packages/msgraph-sdk-applications": {
       "name": "@microsoft/msgraph-sdk-applications",
-      "version": "1.0.0-preview.82",
+      "version": "1.0.0-preview.83",
       "license": "MIT",
       "dependencies": {
         "@microsoft/msgraph-sdk": "^1.0.0-preview.42",
@@ -2327,7 +2178,7 @@
     },
     "packages/msgraph-sdk-applicationTemplates": {
       "name": "@microsoft/msgraph-sdk-applicationtemplates",
-      "version": "1.0.0-preview.82",
+      "version": "1.0.0-preview.83",
       "license": "MIT",
       "dependencies": {
         "@microsoft/msgraph-sdk": "^1.0.0-preview.42",
@@ -2339,7 +2190,7 @@
     },
     "packages/msgraph-sdk-auditLogs": {
       "name": "@microsoft/msgraph-sdk-auditlogs",
-      "version": "1.0.0-preview.82",
+      "version": "1.0.0-preview.83",
       "license": "MIT",
       "dependencies": {
         "@microsoft/msgraph-sdk": "^1.0.0-preview.42",
@@ -2351,7 +2202,7 @@
     },
     "packages/msgraph-sdk-authenticationMethodConfigurations": {
       "name": "@microsoft/msgraph-sdk-authenticationmethodconfigurations",
-      "version": "1.0.0-preview.82",
+      "version": "1.0.0-preview.83",
       "license": "MIT",
       "dependencies": {
         "@microsoft/msgraph-sdk": "^1.0.0-preview.42",
@@ -2363,7 +2214,7 @@
     },
     "packages/msgraph-sdk-authenticationMethodsPolicy": {
       "name": "@microsoft/msgraph-sdk-authenticationmethodspolicy",
-      "version": "1.0.0-preview.82",
+      "version": "1.0.0-preview.83",
       "license": "MIT",
       "dependencies": {
         "@microsoft/msgraph-sdk": "^1.0.0-preview.42",
@@ -2375,7 +2226,7 @@
     },
     "packages/msgraph-sdk-certificateBasedAuthConfiguration": {
       "name": "@microsoft/msgraph-sdk-certificatebasedauthconfiguration",
-      "version": "1.0.0-preview.82",
+      "version": "1.0.0-preview.83",
       "license": "MIT",
       "dependencies": {
         "@microsoft/msgraph-sdk": "^1.0.0-preview.42",
@@ -2387,7 +2238,7 @@
     },
     "packages/msgraph-sdk-chats": {
       "name": "@microsoft/msgraph-sdk-chats",
-      "version": "1.0.0-preview.82",
+      "version": "1.0.0-preview.83",
       "license": "MIT",
       "dependencies": {
         "@microsoft/msgraph-sdk": "^1.0.0-preview.42",
@@ -2399,7 +2250,7 @@
     },
     "packages/msgraph-sdk-communications": {
       "name": "@microsoft/msgraph-sdk-communications",
-      "version": "1.0.0-preview.82",
+      "version": "1.0.0-preview.83",
       "license": "MIT",
       "dependencies": {
         "@microsoft/msgraph-sdk": "^1.0.0-preview.42",
@@ -2411,7 +2262,7 @@
     },
     "packages/msgraph-sdk-compliance": {
       "name": "@microsoft/msgraph-sdk-compliance",
-      "version": "1.0.0-preview.82",
+      "version": "1.0.0-preview.83",
       "license": "MIT",
       "dependencies": {
         "@microsoft/msgraph-sdk": "^1.0.0-preview.42",
@@ -2423,7 +2274,7 @@
     },
     "packages/msgraph-sdk-connections": {
       "name": "@microsoft/msgraph-sdk-connections",
-      "version": "1.0.0-preview.82",
+      "version": "1.0.0-preview.83",
       "license": "MIT",
       "dependencies": {
         "@microsoft/msgraph-sdk": "^1.0.0-preview.42",
@@ -2435,7 +2286,7 @@
     },
     "packages/msgraph-sdk-contacts": {
       "name": "@microsoft/msgraph-sdk-contacts",
-      "version": "1.0.0-preview.82",
+      "version": "1.0.0-preview.83",
       "license": "MIT",
       "dependencies": {
         "@microsoft/msgraph-sdk": "^1.0.0-preview.42",
@@ -2447,7 +2298,7 @@
     },
     "packages/msgraph-sdk-contracts": {
       "name": "@microsoft/msgraph-sdk-contracts",
-      "version": "1.0.0-preview.82",
+      "version": "1.0.0-preview.83",
       "license": "MIT",
       "dependencies": {
         "@microsoft/msgraph-sdk": "^1.0.0-preview.42",
@@ -2459,7 +2310,7 @@
     },
     "packages/msgraph-sdk-dataPolicyOperations": {
       "name": "@microsoft/msgraph-sdk-datapolicyoperations",
-      "version": "1.0.0-preview.82",
+      "version": "1.0.0-preview.83",
       "license": "MIT",
       "dependencies": {
         "@microsoft/msgraph-sdk": "^1.0.0-preview.42",
@@ -2471,7 +2322,7 @@
     },
     "packages/msgraph-sdk-deviceAppManagement": {
       "name": "@microsoft/msgraph-sdk-deviceappmanagement",
-      "version": "1.0.0-preview.82",
+      "version": "1.0.0-preview.83",
       "license": "MIT",
       "dependencies": {
         "@microsoft/msgraph-sdk": "^1.0.0-preview.42",
@@ -2483,7 +2334,7 @@
     },
     "packages/msgraph-sdk-deviceManagement": {
       "name": "@microsoft/msgraph-sdk-devicemanagement",
-      "version": "1.0.0-preview.82",
+      "version": "1.0.0-preview.83",
       "license": "MIT",
       "dependencies": {
         "@microsoft/msgraph-sdk": "^1.0.0-preview.42",
@@ -2495,7 +2346,7 @@
     },
     "packages/msgraph-sdk-devices": {
       "name": "@microsoft/msgraph-sdk-devices",
-      "version": "1.0.0-preview.82",
+      "version": "1.0.0-preview.83",
       "license": "MIT",
       "dependencies": {
         "@microsoft/msgraph-sdk": "^1.0.0-preview.42",
@@ -2507,7 +2358,7 @@
     },
     "packages/msgraph-sdk-directory": {
       "name": "@microsoft/msgraph-sdk-directory",
-      "version": "1.0.0-preview.82",
+      "version": "1.0.0-preview.83",
       "license": "MIT",
       "dependencies": {
         "@microsoft/msgraph-sdk": "^1.0.0-preview.42",
@@ -2519,7 +2370,7 @@
     },
     "packages/msgraph-sdk-directoryObjects": {
       "name": "@microsoft/msgraph-sdk-directoryobjects",
-      "version": "1.0.0-preview.82",
+      "version": "1.0.0-preview.83",
       "license": "MIT",
       "dependencies": {
         "@microsoft/msgraph-sdk": "^1.0.0-preview.42",
@@ -2531,7 +2382,7 @@
     },
     "packages/msgraph-sdk-directoryRoles": {
       "name": "@microsoft/msgraph-sdk-directoryroles",
-      "version": "1.0.0-preview.82",
+      "version": "1.0.0-preview.83",
       "license": "MIT",
       "dependencies": {
         "@microsoft/msgraph-sdk": "^1.0.0-preview.42",
@@ -2543,7 +2394,7 @@
     },
     "packages/msgraph-sdk-directoryRoleTemplates": {
       "name": "@microsoft/msgraph-sdk-directoryroletemplates",
-      "version": "1.0.0-preview.82",
+      "version": "1.0.0-preview.83",
       "license": "MIT",
       "dependencies": {
         "@microsoft/msgraph-sdk": "^1.0.0-preview.42",
@@ -2555,7 +2406,7 @@
     },
     "packages/msgraph-sdk-domainDnsRecords": {
       "name": "@microsoft/msgraph-sdk-domaindnsrecords",
-      "version": "1.0.0-preview.82",
+      "version": "1.0.0-preview.83",
       "license": "MIT",
       "dependencies": {
         "@microsoft/msgraph-sdk": "^1.0.0-preview.42",
@@ -2567,7 +2418,7 @@
     },
     "packages/msgraph-sdk-domains": {
       "name": "@microsoft/msgraph-sdk-domains",
-      "version": "1.0.0-preview.82",
+      "version": "1.0.0-preview.83",
       "license": "MIT",
       "dependencies": {
         "@microsoft/msgraph-sdk": "^1.0.0-preview.42",
@@ -2579,7 +2430,7 @@
     },
     "packages/msgraph-sdk-drives": {
       "name": "@microsoft/msgraph-sdk-drives",
-      "version": "1.0.0-preview.82",
+      "version": "1.0.0-preview.83",
       "license": "MIT",
       "dependencies": {
         "@microsoft/msgraph-sdk": "^1.0.0-preview.42",
@@ -2591,7 +2442,7 @@
     },
     "packages/msgraph-sdk-education": {
       "name": "@microsoft/msgraph-sdk-education",
-      "version": "1.0.0-preview.82",
+      "version": "1.0.0-preview.83",
       "license": "MIT",
       "dependencies": {
         "@microsoft/msgraph-sdk": "^1.0.0-preview.42",
@@ -2603,7 +2454,7 @@
     },
     "packages/msgraph-sdk-employeeExperience": {
       "name": "@microsoft/msgraph-sdk-employeeexperience",
-      "version": "1.0.0-preview.82",
+      "version": "1.0.0-preview.83",
       "license": "MIT",
       "dependencies": {
         "@microsoft/msgraph-sdk": "^1.0.0-preview.42",
@@ -2615,7 +2466,7 @@
     },
     "packages/msgraph-sdk-external": {
       "name": "@microsoft/msgraph-sdk-external",
-      "version": "1.0.0-preview.82",
+      "version": "1.0.0-preview.83",
       "license": "MIT",
       "dependencies": {
         "@microsoft/msgraph-sdk": "^1.0.0-preview.42",
@@ -2627,7 +2478,7 @@
     },
     "packages/msgraph-sdk-filterOperators": {
       "name": "@microsoft/msgraph-sdk-filteroperators",
-      "version": "1.0.0-preview.82",
+      "version": "1.0.0-preview.83",
       "license": "MIT",
       "dependencies": {
         "@microsoft/msgraph-sdk": "^1.0.0-preview.42",
@@ -2639,7 +2490,7 @@
     },
     "packages/msgraph-sdk-functions": {
       "name": "@microsoft/msgraph-sdk-functions",
-      "version": "1.0.0-preview.82",
+      "version": "1.0.0-preview.83",
       "license": "MIT",
       "dependencies": {
         "@microsoft/msgraph-sdk": "^1.0.0-preview.42",
@@ -2651,7 +2502,7 @@
     },
     "packages/msgraph-sdk-groupLifecyclePolicies": {
       "name": "@microsoft/msgraph-sdk-grouplifecyclepolicies",
-      "version": "1.0.0-preview.82",
+      "version": "1.0.0-preview.83",
       "license": "MIT",
       "dependencies": {
         "@microsoft/msgraph-sdk": "^1.0.0-preview.42",
@@ -2663,7 +2514,7 @@
     },
     "packages/msgraph-sdk-groups": {
       "name": "@microsoft/msgraph-sdk-groups",
-      "version": "1.0.0-preview.82",
+      "version": "1.0.0-preview.83",
       "license": "MIT",
       "dependencies": {
         "@microsoft/msgraph-sdk": "^1.0.0-preview.42",
@@ -2675,7 +2526,7 @@
     },
     "packages/msgraph-sdk-groupSettings": {
       "name": "@microsoft/msgraph-sdk-groupsettings",
-      "version": "1.0.0-preview.82",
+      "version": "1.0.0-preview.83",
       "license": "MIT",
       "dependencies": {
         "@microsoft/msgraph-sdk": "^1.0.0-preview.42",
@@ -2687,7 +2538,7 @@
     },
     "packages/msgraph-sdk-groupSettingTemplates": {
       "name": "@microsoft/msgraph-sdk-groupsettingtemplates",
-      "version": "1.0.0-preview.82",
+      "version": "1.0.0-preview.83",
       "license": "MIT",
       "dependencies": {
         "@microsoft/msgraph-sdk": "^1.0.0-preview.42",
@@ -2699,7 +2550,7 @@
     },
     "packages/msgraph-sdk-identity": {
       "name": "@microsoft/msgraph-sdk-identity",
-      "version": "1.0.0-preview.82",
+      "version": "1.0.0-preview.83",
       "license": "MIT",
       "dependencies": {
         "@microsoft/msgraph-sdk": "^1.0.0-preview.42",
@@ -2711,7 +2562,7 @@
     },
     "packages/msgraph-sdk-identityGovernance": {
       "name": "@microsoft/msgraph-sdk-identitygovernance",
-      "version": "1.0.0-preview.82",
+      "version": "1.0.0-preview.83",
       "license": "MIT",
       "dependencies": {
         "@microsoft/msgraph-sdk": "^1.0.0-preview.42",
@@ -2723,7 +2574,7 @@
     },
     "packages/msgraph-sdk-identityProtection": {
       "name": "@microsoft/msgraph-sdk-identityprotection",
-      "version": "1.0.0-preview.82",
+      "version": "1.0.0-preview.83",
       "license": "MIT",
       "dependencies": {
         "@microsoft/msgraph-sdk": "^1.0.0-preview.42",
@@ -2735,7 +2586,7 @@
     },
     "packages/msgraph-sdk-identityProviders": {
       "name": "@microsoft/msgraph-sdk-identityproviders",
-      "version": "1.0.0-preview.82",
+      "version": "1.0.0-preview.83",
       "license": "MIT",
       "dependencies": {
         "@microsoft/msgraph-sdk": "^1.0.0-preview.42",
@@ -2747,7 +2598,7 @@
     },
     "packages/msgraph-sdk-informationProtection": {
       "name": "@microsoft/msgraph-sdk-informationprotection",
-      "version": "1.0.0-preview.82",
+      "version": "1.0.0-preview.83",
       "license": "MIT",
       "dependencies": {
         "@microsoft/msgraph-sdk": "^1.0.0-preview.42",
@@ -2759,7 +2610,7 @@
     },
     "packages/msgraph-sdk-invitations": {
       "name": "@microsoft/msgraph-sdk-invitations",
-      "version": "1.0.0-preview.82",
+      "version": "1.0.0-preview.83",
       "license": "MIT",
       "dependencies": {
         "@microsoft/msgraph-sdk": "^1.0.0-preview.42",
@@ -2771,7 +2622,7 @@
     },
     "packages/msgraph-sdk-oauth2PermissionGrants": {
       "name": "@microsoft/msgraph-sdk-oauth2permissiongrants",
-      "version": "1.0.0-preview.82",
+      "version": "1.0.0-preview.83",
       "license": "MIT",
       "dependencies": {
         "@microsoft/msgraph-sdk": "^1.0.0-preview.42",
@@ -2783,7 +2634,7 @@
     },
     "packages/msgraph-sdk-organization": {
       "name": "@microsoft/msgraph-sdk-organization",
-      "version": "1.0.0-preview.82",
+      "version": "1.0.0-preview.83",
       "license": "MIT",
       "dependencies": {
         "@microsoft/msgraph-sdk": "^1.0.0-preview.42",
@@ -2795,7 +2646,7 @@
     },
     "packages/msgraph-sdk-permissionGrants": {
       "name": "@microsoft/msgraph-sdk-permissiongrants",
-      "version": "1.0.0-preview.82",
+      "version": "1.0.0-preview.83",
       "license": "MIT",
       "dependencies": {
         "@microsoft/msgraph-sdk": "^1.0.0-preview.42",
@@ -2807,7 +2658,7 @@
     },
     "packages/msgraph-sdk-places": {
       "name": "@microsoft/msgraph-sdk-places",
-      "version": "1.0.0-preview.82",
+      "version": "1.0.0-preview.83",
       "license": "MIT",
       "dependencies": {
         "@microsoft/msgraph-sdk": "^1.0.0-preview.42",
@@ -2819,7 +2670,7 @@
     },
     "packages/msgraph-sdk-planner": {
       "name": "@microsoft/msgraph-sdk-planner",
-      "version": "1.0.0-preview.82",
+      "version": "1.0.0-preview.83",
       "license": "MIT",
       "dependencies": {
         "@microsoft/msgraph-sdk": "^1.0.0-preview.42",
@@ -2831,7 +2682,7 @@
     },
     "packages/msgraph-sdk-policies": {
       "name": "@microsoft/msgraph-sdk-policies",
-      "version": "1.0.0-preview.82",
+      "version": "1.0.0-preview.83",
       "license": "MIT",
       "dependencies": {
         "@microsoft/msgraph-sdk": "^1.0.0-preview.42",
@@ -2843,7 +2694,7 @@
     },
     "packages/msgraph-sdk-print": {
       "name": "@microsoft/msgraph-sdk-print",
-      "version": "1.0.0-preview.82",
+      "version": "1.0.0-preview.83",
       "license": "MIT",
       "dependencies": {
         "@microsoft/msgraph-sdk": "^1.0.0-preview.42",
@@ -2855,7 +2706,7 @@
     },
     "packages/msgraph-sdk-privacy": {
       "name": "@microsoft/msgraph-sdk-privacy",
-      "version": "1.0.0-preview.82",
+      "version": "1.0.0-preview.83",
       "license": "MIT",
       "dependencies": {
         "@microsoft/msgraph-sdk": "^1.0.0-preview.42",
@@ -2867,7 +2718,7 @@
     },
     "packages/msgraph-sdk-reports": {
       "name": "@microsoft/msgraph-sdk-reports",
-      "version": "1.0.0-preview.82",
+      "version": "1.0.0-preview.83",
       "license": "MIT",
       "dependencies": {
         "@microsoft/msgraph-sdk": "^1.0.0-preview.42",
@@ -2879,7 +2730,7 @@
     },
     "packages/msgraph-sdk-roleManagement": {
       "name": "@microsoft/msgraph-sdk-rolemanagement",
-      "version": "1.0.0-preview.82",
+      "version": "1.0.0-preview.83",
       "license": "MIT",
       "dependencies": {
         "@microsoft/msgraph-sdk": "^1.0.0-preview.42",
@@ -2891,7 +2742,7 @@
     },
     "packages/msgraph-sdk-schemaExtensions": {
       "name": "@microsoft/msgraph-sdk-schemaextensions",
-      "version": "1.0.0-preview.82",
+      "version": "1.0.0-preview.83",
       "license": "MIT",
       "dependencies": {
         "@microsoft/msgraph-sdk": "^1.0.0-preview.42",
@@ -2903,7 +2754,7 @@
     },
     "packages/msgraph-sdk-scopedRoleMemberships": {
       "name": "@microsoft/msgraph-sdk-scopedrolememberships",
-      "version": "1.0.0-preview.82",
+      "version": "1.0.0-preview.83",
       "license": "MIT",
       "dependencies": {
         "@microsoft/msgraph-sdk": "^1.0.0-preview.42",
@@ -2915,7 +2766,7 @@
     },
     "packages/msgraph-sdk-search": {
       "name": "@microsoft/msgraph-sdk-search",
-      "version": "1.0.0-preview.82",
+      "version": "1.0.0-preview.83",
       "license": "MIT",
       "dependencies": {
         "@microsoft/msgraph-sdk": "^1.0.0-preview.42",
@@ -2927,7 +2778,7 @@
     },
     "packages/msgraph-sdk-security": {
       "name": "@microsoft/msgraph-sdk-security",
-      "version": "1.0.0-preview.82",
+      "version": "1.0.0-preview.83",
       "license": "MIT",
       "dependencies": {
         "@microsoft/msgraph-sdk": "^1.0.0-preview.42",
@@ -2939,7 +2790,7 @@
     },
     "packages/msgraph-sdk-servicePrincipals": {
       "name": "@microsoft/msgraph-sdk-serviceprincipals",
-      "version": "1.0.0-preview.82",
+      "version": "1.0.0-preview.83",
       "license": "MIT",
       "dependencies": {
         "@microsoft/msgraph-sdk": "^1.0.0-preview.42",
@@ -2951,7 +2802,7 @@
     },
     "packages/msgraph-sdk-shares": {
       "name": "@microsoft/msgraph-sdk-shares",
-      "version": "1.0.0-preview.82",
+      "version": "1.0.0-preview.83",
       "license": "MIT",
       "dependencies": {
         "@microsoft/msgraph-sdk": "^1.0.0-preview.42",
@@ -2963,7 +2814,7 @@
     },
     "packages/msgraph-sdk-sites": {
       "name": "@microsoft/msgraph-sdk-sites",
-      "version": "1.0.0-preview.82",
+      "version": "1.0.0-preview.83",
       "license": "MIT",
       "dependencies": {
         "@microsoft/msgraph-sdk": "^1.0.0-preview.42",
@@ -2975,7 +2826,7 @@
     },
     "packages/msgraph-sdk-solutions": {
       "name": "@microsoft/msgraph-sdk-solutions",
-      "version": "1.0.0-preview.82",
+      "version": "1.0.0-preview.83",
       "license": "MIT",
       "dependencies": {
         "@microsoft/msgraph-sdk": "^1.0.0-preview.42",
@@ -2987,7 +2838,7 @@
     },
     "packages/msgraph-sdk-subscribedSkus": {
       "name": "@microsoft/msgraph-sdk-subscribedskus",
-      "version": "1.0.0-preview.82",
+      "version": "1.0.0-preview.83",
       "license": "MIT",
       "dependencies": {
         "@microsoft/msgraph-sdk": "^1.0.0-preview.42",
@@ -2999,7 +2850,7 @@
     },
     "packages/msgraph-sdk-subscriptions": {
       "name": "@microsoft/msgraph-sdk-subscriptions",
-      "version": "1.0.0-preview.82",
+      "version": "1.0.0-preview.83",
       "license": "MIT",
       "dependencies": {
         "@microsoft/msgraph-sdk": "^1.0.0-preview.42",
@@ -3011,7 +2862,7 @@
     },
     "packages/msgraph-sdk-teams": {
       "name": "@microsoft/msgraph-sdk-teams",
-      "version": "1.0.0-preview.82",
+      "version": "1.0.0-preview.83",
       "license": "MIT",
       "dependencies": {
         "@microsoft/msgraph-sdk": "^1.0.0-preview.42",
@@ -3023,7 +2874,7 @@
     },
     "packages/msgraph-sdk-teamsTemplates": {
       "name": "@microsoft/msgraph-sdk-teamstemplates",
-      "version": "1.0.0-preview.82",
+      "version": "1.0.0-preview.83",
       "license": "MIT",
       "dependencies": {
         "@microsoft/msgraph-sdk": "^1.0.0-preview.42",
@@ -3035,7 +2886,7 @@
     },
     "packages/msgraph-sdk-teamwork": {
       "name": "@microsoft/msgraph-sdk-teamwork",
-      "version": "1.0.0-preview.82",
+      "version": "1.0.0-preview.83",
       "license": "MIT",
       "dependencies": {
         "@microsoft/msgraph-sdk": "^1.0.0-preview.42",
@@ -3047,7 +2898,7 @@
     },
     "packages/msgraph-sdk-tenantRelationships": {
       "name": "@microsoft/msgraph-sdk-tenantrelationships",
-      "version": "1.0.0-preview.82",
+      "version": "1.0.0-preview.83",
       "license": "MIT",
       "dependencies": {
         "@microsoft/msgraph-sdk": "^1.0.0-preview.42",
@@ -3059,7 +2910,7 @@
     },
     "packages/msgraph-sdk-tests": {
       "name": "@microsoft/msgraph-sdk-tests",
-      "version": "1.0.0-preview.82",
+      "version": "1.0.0-preview.83",
       "license": "MIT",
       "dependencies": {
         "@azure/identity": "^4.13.1",
@@ -3080,7 +2931,7 @@
     },
     "packages/msgraph-sdk-users": {
       "name": "@microsoft/msgraph-sdk-users",
-      "version": "1.0.0-preview.82",
+      "version": "1.0.0-preview.83",
       "license": "MIT",
       "dependencies": {
         "@microsoft/msgraph-sdk": "^1.0.0-preview.42",


### PR DESCRIPTION
## Summary

Updates @microsoft/kiota-http-fetchlibrary and related packages to address **GHSA-396q-4vc8-28x9**, a critical security vulnerability that leaks Bearer tokens across HTTP redirects.

## Changes

- **@microsoft/kiota-authentication-azure**: 1.0.0-preview.100 → 1.0.0-preview.102
- **@microsoft/kiota-bundle**: 1.0.0-preview.100 → 1.0.0-preview.102
- **@types/chai**: 5.2.2 → 5.2.3
- **@types/node**: 25.2.3 → 25.9.1
- **mocha**: 11.7.5 → 11.7.6

## Vulnerability Details

The `RedirectHandler` in @microsoft/kiota-http-fetchlibrary contains a case-sensitivity bug where sensitive headers (`Authorization`, `Cookie`) are forwarded to attacker-controlled hosts across 30x redirects.

Fixes #994