### PR TITLE
chore: replace .npmrc creation with npm@1 task in daily CI build

### DIFF
--- a/.azure-pipelines/daily-ci-build.yml
+++ b/.azure-pipelines/daily-ci-build.yml
@@ -48,20 +48,14 @@ extends:
                 inputs:
                   versionSpec: '20.x'
 
-              - script: |
-                  echo "registry=$(NPM_REGISTRY_URL)" > .npmrc
-                  echo "always-auth=true" >> .npmrc
-                displayName: Create .npmrc for Azure Artifacts feed
-                workingDirectory: $(Build.SourcesDirectory)
-
-              - task: npmAuthenticate@0
-                displayName: Authenticate npm
-                inputs:
-                  workingFile: $(Build.SourcesDirectory)/.npmrc
-
-              - script: npm ci
+              - task: npm@1
                 displayName: Install dependencies
-                workingDirectory: $(Build.SourcesDirectory)
+                inputs:
+                  command: 'ci'
+                  verbose: true
+                  customRegistry: 'useFeed'
+                  customFeed: 'Graph Developer Experiences/msgraph-typescript'
+                  workingDir: '$(Build.SourcesDirectory)'
 
               - script: npm run build --workspaces
                 displayName: Build SDK


### PR DESCRIPTION
Replace the 3-step .npmrc creation, npmAuthenticate, and npm ci script with a single npm@1 task using customRegistry/customFeed, matching the pattern from microsoftgraph/msgraph-sdk-typescript-core#583.

A similar PR may already be submitted! Please search among the [Pull request](https://github.com/microsoftgraph/msgraph-sdk-typescript/pulls) before creating one.

Thanks for submitting a pull request! Please provide enough information so that others can review your pull request.

**NOTE: PR's will be accepted only in case of appropriate information is provided below**

## Summary

<!-- Summary of the PR -->

## Motivation

Explain the **motivation** for making this change. What existing problem does the pull request solve?

<!-- Example: When "Adding a function to do X", explain why it is necessary to have a way to do X. -->

## Test plan

Demonstrate the code is solid. Example: The exact commands you ran and their output.

<!-- Make sure tests pass on Travis CI. -->

## Closing issues

<!-- Put `closes #XXXX` in your comment to auto-close the issue that your PR fixes (if such). -->

Fixes #

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

-   [ ] Bug fix (non-breaking change which fixes an issue)
-   [ ] New feature (non-breaking change which adds functionality)
-   [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist

-   [ ] I have read the **CONTRIBUTING** document.
-   [ ] My code follows the code style of this project.
-   [ ] My change requires a change to the documentation.
-   [ ] I have updated the documentation accordingly.
-   [ ] I have added tests to cover my changes.
-   [ ] All new and existing tests passed.
