### PR TITLE
chore(deps): consolidate open dependabot dependency updates

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -25,7 +25,7 @@ jobs:
         # Single version should work for compilation testing
 
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@v7
       - name: Use Node.js ${{ matrix.node-version }}
         uses: actions/setup-node@v6
         with:

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -46,7 +46,7 @@ jobs:
 
     steps:
     - name: Checkout repository
-      uses: actions/checkout@v6
+      uses: actions/checkout@v7
 
     # Initializes the CodeQL tools for scanning.
     - name: Initialize CodeQL

--- a/.github/workflows/release-please-gha.yml
+++ b/.github/workflows/release-please-gha.yml
@@ -19,7 +19,7 @@ jobs:
   release:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@v7
 
       - name: Generate GitHub App token
         id: app-token

--- a/.github/workflows/validate-public-api-surface.yml
+++ b/.github/workflows/validate-public-api-surface.yml
@@ -15,7 +15,7 @@ jobs:
   build:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@v7
       - uses: microsoftgraph/kiota-dom-export-diff-tool/export@main
         id: generatePatch
       - uses: microsoftgraph/kiota-dom-export-diff-tool/tool@main

--- a/package-lock.json
+++ b/package-lock.json
@@ -703,13 +703,13 @@
       "license": "MIT"
     },
     "node_modules/@types/node": {
-      "version": "25.9.1",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-25.9.1.tgz",
-      "integrity": "sha512-xfrlY7UD5rMJk3ZVJP8BNzS28J36YJg+xp+LPXV1TdWxr8uMH5A860QNxYDGQe/ylDSgjxE52Q9VnO7p75tJxg==",
+      "version": "26.1.0",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-26.1.0.tgz",
+      "integrity": "sha512-O0A1G3xPGy4w7AgQdAQYUlQ+BKk2Oovw8eRpofyp5KdBZULnbe+WqaOVNrm705SHphCiG4XHsACrSmPu1f+Kgw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "undici-types": ">=7.24.0 <7.24.7"
+        "undici-types": "~8.3.0"
       }
     },
     "node_modules/@typespec/ts-http-runtime": {
@@ -1954,9 +1954,9 @@
       }
     },
     "node_modules/undici-types": {
-      "version": "7.24.6",
-      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-7.24.6.tgz",
-      "integrity": "sha512-WRNW+sJgj5OBN4/0JpHFqtqzhpbnV0GuB+OozA9gCL7a993SmU+1JBZCzLNxYsbMfIeDL+lTsphD5jN5N+n0zg==",
+      "version": "8.3.0",
+      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-8.3.0.tgz",
+      "integrity": "sha512-j375ScV60dom+YkPFIfTLcOiPxkN/buHz5GobjLhixFuANaNs3C9l4GmrWqejgXWJ7BbJcFYpTEUkS1Ge8bpZQ==",
       "dev": true,
       "license": "MIT"
     },
@@ -2112,7 +2112,7 @@
         "tslib": "^2.6.2"
       },
       "devDependencies": {
-        "@types/node": "^25.9.0",
+        "@types/node": "^26.1.0",
         "typescript": "^6.0.3"
       }
     },
@@ -2924,7 +2924,7 @@
       "devDependencies": {
         "@types/chai": "^5.0.0",
         "@types/mocha": "^10.0.6",
-        "@types/node": "^25.9.0",
+        "@types/node": "^26.1.0",
         "chai": "^6.0.1",
         "mocha": "^11.0.1"
       }

--- a/packages/msgraph-sdk-tests/package.json
+++ b/packages/msgraph-sdk-tests/package.json
@@ -34,7 +34,7 @@
   "devDependencies": {
     "@types/chai": "^5.0.0",
     "@types/mocha": "^10.0.6",
-    "@types/node": "^25.9.0",
+    "@types/node": "^26.1.0",
     "chai": "^6.0.1",
     "mocha": "^11.0.1"
   },

--- a/packages/msgraph-sdk/package.json
+++ b/packages/msgraph-sdk/package.json
@@ -31,7 +31,7 @@
     "tslib": "^2.6.2"
   },
   "devDependencies": {
-    "@types/node": "^25.9.0",
+    "@types/node": "^26.1.0",
     "typescript": "^6.0.3"
   },
   "type": "module"


### PR DESCRIPTION
| Package/Action | From | To | Source PR |
| --- | --- | --- | --- |
| @types/node (@microsoft/msgraph-sdk) | ^25.9.0 | ^26.1.0 | #1015 |
| @types/node (@microsoft/msgraph-sdk-tests) | ^25.9.0 | ^26.1.0 | #1016 |
| actions/checkout | v6 | v7 | #1004 |

Regenerated the root package-lock.json with npm install so the workspace lockfile includes @types/node@26.1.0 and undici-types@8.3.0, allowing npm ci to pass for the tests workspace.

Closes #1015
Closes #1016
Closes #1004